### PR TITLE
Use global regex with replaceAll

### DIFF
--- a/services/course-material/src/components/ContentRenderer/ParagraphBlock.tsx
+++ b/services/course-material/src/components/ContentRenderer/ParagraphBlock.tsx
@@ -14,7 +14,7 @@ interface ParagraphBlockAttributes {
   fontSize?: string
 }
 
-const LATEX_REGEX = /\[latex\](.*)\[\/latex\]/
+const LATEX_REGEX = /\[latex\](.*)\[\/latex\]/g
 /**
  *
  * @param data HTML-content from the server


### PR DESCRIPTION
Course material page with latex was crashing with a message saying that the regex given to `replaceAll` should be global.