### PR TITLE
Use htmlAndMathml Katex output for accessibility

### DIFF
--- a/services/cms/src/blocks/Latex/LatexEditor.tsx
+++ b/services/cms/src/blocks/Latex/LatexEditor.tsx
@@ -33,7 +33,6 @@ const LatexEditor: React.FC<BlockEditProps<TextAttributes>> = (props) => {
     const output = KaTex.renderToString(attributes.text, {
       throwOnError: false,
       displayMode: true,
-      // eslint-disable-next-line i18next/no-literal-string
       output: KATEX_OUTPUT_FORMAT,
     })
     return <div dangerouslySetInnerHTML={{ __html: output }} />

--- a/services/cms/src/blocks/Latex/LatexEditor.tsx
+++ b/services/cms/src/blocks/Latex/LatexEditor.tsx
@@ -7,6 +7,8 @@ import React from "react"
 import "katex/dist/katex.min.css"
 import { TextAttributes } from "."
 
+const KATEX_OUTPUT_FORMAT = "htmlAndMathml"
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -32,7 +34,7 @@ const LatexEditor: React.FC<BlockEditProps<TextAttributes>> = (props) => {
       throwOnError: false,
       displayMode: true,
       // eslint-disable-next-line i18next/no-literal-string
-      output: "html",
+      output: KATEX_OUTPUT_FORMAT,
     })
     return <div dangerouslySetInnerHTML={{ __html: output }} />
   }

--- a/services/course-material/src/components/ContentRenderer/core/common/Paragraph/index.tsx
+++ b/services/course-material/src/components/ContentRenderer/core/common/Paragraph/index.tsx
@@ -19,7 +19,7 @@ const LatexParagraph = dynamic(() => import("./LatexParagraph"))
 
 const LATEX_REGEX = /\[latex\](.*)\[\/latex\]/g
 const HTML_ESCAPED_AMPERSAND = "&amp;"
-const KATEX_OUTPUT_FORMAT = "html"
+const KATEX_OUTPUT_FORMAT = "htmlAndMathml"
 
 /**
  *

--- a/services/course-material/src/components/ContentRenderer/moocfi/LatexBlock.tsx
+++ b/services/course-material/src/components/ContentRenderer/moocfi/LatexBlock.tsx
@@ -7,7 +7,7 @@ export interface TextAttributes {
   text: string
 }
 
-const KATEX_OUTPUT_FORMAT = "html"
+const KATEX_OUTPUT_FORMAT = "htmlAndMathml"
 
 const LatexBlock: React.FC<BlockRendererProps<TextAttributes>> = ({ data }) => {
   const attributes: TextAttributes = data.attributes


### PR DESCRIPTION
Screen readers are able to read MathML output so it makes sense to include that in addition to the html output.