### PR TITLE
Move ts_rs behind a feature

### DIFF
--- a/bin/generate-doc-files
+++ b/bin/generate-doc-files
@@ -11,7 +11,7 @@ RELATIVE_PATH=$(realpath --relative-to="$(pwd)" "$FOLDER_PATH")
 
 run_command cd "$RELATIVE_PATH" || exit
 
-run_command cargo run --bin doc-file-generator
+run_command cargo run --bin doc-file-generator --features ts_rs
 
 # Fix formatting
 run_command npm run eslint:format-generated-docs

--- a/docs/headless-lms.md
+++ b/docs/headless-lms.md
@@ -123,7 +123,7 @@ Not all of the traits can be derived for every struct. In those cases, it's fine
 
 Some structures and enums are also used by frontend services, primarily those that represent a request or response data. When these types are either changed or new ones added, their type bindings need to be regenerated.
 
-The configuration for which types should be generated is located in `/services/headless-lms/src/ts_binding_generator.rs`. Any new type added there should derive the `ts_rs::TS` type.
+The configuration for which types should be generated is located in `/services/headless-lms/src/ts_binding_generator.rs`. Any new type added there should derive the `ts_rs::TS` type. The ts_rs crate is behind a feature flag for [compilation performance reasons](https://github.com/rage/secret-project-331/pull/685), so you need to do the derive like this: `#[cfg_attr(feature = "ts_rs", derive(TS))]`.
 
 To generate bindings, run the `bin/generate-bindings` binary. This will generate bindings for all services and makes sure they are properly formated.
 

--- a/services/headless-lms/models/Cargo.toml
+++ b/services/headless-lms/models/Cargo.toml
@@ -52,7 +52,7 @@ ts-rs = { git = "https://github.com/Heliozoa/ts-rs", rev = "3d0fd4f71fd1698e4236
   "serde-compat",
   "serde-json-impl",
   "uuid-impl",
-] }
+], optional = true }
 # Email client
 lettre = "0.10.0-rc.4"
 
@@ -70,3 +70,6 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 # Random number generators and other randomness functionality.
 rand = "0.8.5"
+
+[features]
+ts_rs = ["ts-rs"]

--- a/services/headless-lms/models/src/chapters.rs
+++ b/services/headless-lms/models/src/chapters.rs
@@ -10,7 +10,8 @@ use headless_lms_utils::{
     numbers::option_f32_to_f32_two_decimals, ApplicationConfiguration,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct DatabaseChapter {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -26,7 +27,8 @@ pub struct DatabaseChapter {
     pub copied_from: Option<Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Chapter {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -69,7 +71,8 @@ impl Chapter {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[serde(rename_all = "snake_case")]
 pub enum ChapterStatus {
     Open,
@@ -95,7 +98,8 @@ pub struct ChapterPagesWithExercises {
 }
 
 // Represents the subset of page fields that are required to create a new course.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewChapter {
     pub name: String,
     pub course_id: Uuid,
@@ -105,7 +109,8 @@ pub struct NewChapter {
     pub deadline: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ChapterUpdate {
     pub name: String,
     pub front_page_id: Option<Uuid>,
@@ -250,7 +255,8 @@ RETURNING *;",
     Ok(updated_chapter)
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ChapterWithStatus {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -263,7 +269,8 @@ pub struct ChapterWithStatus {
     pub opens_at: Option<DateTime<Utc>>,
     pub status: ChapterStatus,
 }
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct UserCourseInstanceChapterProgress {
     pub score_given: f32,
     pub score_maximum: i32,

--- a/services/headless-lms/models/src/course_instance_enrollments.rs
+++ b/services/headless-lms/models/src/course_instance_enrollments.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseInstanceEnrollment {
     pub user_id: Uuid,
     pub course_id: Uuid,

--- a/services/headless-lms/models/src/course_instances.rs
+++ b/services/headless-lms/models/src/course_instances.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use crate::{chapters, chapters::DatabaseChapter, exercises, prelude::*, users::User};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseInstance {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -18,7 +19,8 @@ pub struct CourseInstance {
     pub support_email: Option<String>,
 }
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseInstanceForm {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -258,7 +260,8 @@ WHERE course_id = $1
     Ok(course_instances)
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ChapterScore {
     #[serde(flatten)]
     pub chapter: DatabaseChapter,
@@ -266,10 +269,12 @@ pub struct ChapterScore {
     pub score_total: i32,
 }
 
-#[derive(Debug, Default, Serialize, TS)]
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PointMap(pub HashMap<Uuid, f32>);
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Points {
     pub chapter_points: Vec<ChapterScore>,
     pub users: Vec<User>,

--- a/services/headless-lms/models/src/courses.rs
+++ b/services/headless-lms/models/src/courses.rs
@@ -19,12 +19,14 @@ pub struct CourseInfo {
     pub is_draft: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseCount {
     pub count: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Course {
     pub id: Uuid,
     pub slug: String,
@@ -41,7 +43,8 @@ pub struct Course {
     pub is_draft: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseStructure {
     pub course: Course,
     pub pages: Vec<Page>,
@@ -614,7 +617,8 @@ WHERE organization_id = $1
 }
 
 // Represents the subset of page fields that are required to create a new course.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewCourse {
     pub name: String,
     pub slug: String,
@@ -710,7 +714,8 @@ RETURNING id,
 }
 
 // Represents the subset of page fields that one is allowed to update in a course
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseUpdate {
     name: String,
     is_draft: bool,

--- a/services/headless-lms/models/src/email_templates.rs
+++ b/services/headless-lms/models/src/email_templates.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct EmailTemplate {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -14,12 +15,14 @@ pub struct EmailTemplate {
     pub course_instance_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct EmailTemplateNew {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct EmailTemplateUpdate {
     pub name: String,
     pub subject: String,

--- a/services/headless-lms/models/src/exams.rs
+++ b/services/headless-lms/models/src/exams.rs
@@ -3,7 +3,8 @@ use chrono::Duration;
 use crate::{courses::Course, prelude::*};
 use headless_lms_utils::document_schema_processor::GutenbergBlock;
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Exam {
     pub id: Uuid,
     pub name: String,
@@ -71,7 +72,8 @@ WHERE course_exams.exam_id = $1
     })
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseExam {
     pub id: Uuid,
     pub course_id: Uuid,
@@ -90,13 +92,15 @@ pub struct NewExam<'a> {
     pub organization_id: Uuid,
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExamInstructions {
     pub id: Uuid,
     pub instructions: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExamInstructionsUpdate {
     pub instructions: serde_json::Value,
 }
@@ -271,7 +275,8 @@ pub async fn verify_exam_submission_can_be_made(
     Ok(student_has_time && exam_is_ongoing)
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExamEnrollment {
     pub user_id: Uuid,
     pub exam_id: Uuid,

--- a/services/headless-lms/models/src/exercise_service_info.rs
+++ b/services/headless-lms/models/src/exercise_service_info.rs
@@ -30,12 +30,14 @@ pub struct PathInfo {
     pub model_solution_path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseMaterialExerciseServiceInfo {
     pub exercise_iframe_url: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseServiceInfoApi {
     pub service_name: String,
     pub exercise_type_specific_user_interface_iframe: String,

--- a/services/headless-lms/models/src/exercise_services.rs
+++ b/services/headless-lms/models/src/exercise_services.rs
@@ -2,7 +2,8 @@ use url::Url;
 
 use crate::{exercise_service_info::ExerciseServiceInfo, prelude::*};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseService {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -16,7 +17,8 @@ pub struct ExerciseService {
     pub max_reprocessing_submissions_at_once: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseServiceNewOrUpdate {
     pub name: String,
     pub slug: String,

--- a/services/headless-lms/models/src/exercise_slide_submissions.rs
+++ b/services/headless-lms/models/src/exercise_slide_submissions.rs
@@ -13,7 +13,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewExerciseSlideSubmission {
     pub exercise_slide_id: Uuid,
     pub course_id: Option<Uuid>,
@@ -23,7 +24,8 @@ pub struct NewExerciseSlideSubmission {
     pub user_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSlideSubmission {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -37,20 +39,23 @@ pub struct ExerciseSlideSubmission {
     pub user_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSlideSubmissionCount {
     pub date: Option<NaiveDate>,
     pub count: Option<i32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSlideSubmissionCountByExercise {
     pub exercise_id: Option<Uuid>,
     pub count: Option<i32>,
     pub exercise_name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSlideSubmissionCountByWeekAndHour {
     pub isodow: Option<i32>,
     pub hour: Option<i32>,
@@ -58,13 +63,15 @@ pub struct ExerciseSlideSubmissionCountByWeekAndHour {
 }
 
 /// Contains data sent by the student when they make a submission for an exercise slide.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct StudentExerciseSlideSubmission {
     exercise_slide_id: Uuid,
     exercise_task_submissions: Vec<StudentExerciseTaskSubmission>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct StudentExerciseSlideSubmissionResult {
     pub exercise_status: Option<ExerciseStatus>,
     pub exercise_task_submission_results: Vec<StudentExerciseTaskSubmissionResult>,

--- a/services/headless-lms/models/src/exercise_slides.rs
+++ b/services/headless-lms/models/src/exercise_slides.rs
@@ -8,7 +8,8 @@ pub struct NewExerciseSlide {
     order_number: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSlide {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -18,7 +19,8 @@ pub struct ExerciseSlide {
     pub order_number: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseMaterialExerciseSlide {
     pub id: Uuid,
     pub exercise_tasks: Vec<CourseMaterialExerciseTask>,

--- a/services/headless-lms/models/src/exercise_task_gradings.rs
+++ b/services/headless-lms/models/src/exercise_task_gradings.rs
@@ -15,7 +15,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseTaskGrading {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -44,7 +45,8 @@ pub struct ExerciseTaskGradingRequest<'a> {
     pub submission_data: &'a Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseTaskGradingResult {
     pub grading_progress: GradingProgress,
     pub score_given: f32,
@@ -53,7 +55,8 @@ pub struct ExerciseTaskGradingResult {
     pub feedback_json: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "user_points_update_strategy", rename_all = "kebab-case")]
 pub enum UserPointsUpdateStrategy {
     CanAddPointsButCannotRemovePoints,

--- a/services/headless-lms/models/src/exercise_task_submissions.rs
+++ b/services/headless-lms/models/src/exercise_task_submissions.rs
@@ -10,7 +10,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseTaskSubmission {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -24,7 +25,8 @@ pub struct ExerciseTaskSubmission {
     pub metadata: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct SubmissionInfo {
     pub submission: ExerciseTaskSubmission,
     pub exercise: Exercise,
@@ -33,7 +35,8 @@ pub struct SubmissionInfo {
     pub iframe_path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct SubmissionData {
     pub exercise_id: Uuid,
     pub course_id: Uuid,
@@ -46,20 +49,23 @@ pub struct SubmissionData {
     pub id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct StudentExerciseTaskSubmission {
     pub exercise_task_id: Uuid,
     pub data_json: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct StudentExerciseTaskSubmissionResult {
     pub submission: ExerciseTaskSubmission,
     pub grading: Option<ExerciseTaskGrading>,
     pub model_solution_spec: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExportedSubmission {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/services/headless-lms/models/src/exercise_tasks.rs
+++ b/services/headless-lms/models/src/exercise_tasks.rs
@@ -16,7 +16,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseMaterialExerciseTask {
     pub id: Uuid,
     pub exercise_slide_id: Uuid,
@@ -32,7 +33,8 @@ pub struct CourseMaterialExerciseTask {
     pub previous_submission_grading: Option<ExerciseTaskGrading>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseTask {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,

--- a/services/headless-lms/models/src/exercises.rs
+++ b/services/headless-lms/models/src/exercises.rs
@@ -8,7 +8,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Exercise {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -25,7 +26,8 @@ pub struct Exercise {
     pub copied_from: Option<Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CourseMaterialExercise {
     pub exercise: Exercise,
     pub can_post_submission: bool,
@@ -52,7 +54,8 @@ Indicates what is the user's completion status for a exercise.
 
 As close as possible to LTI's activity progress for compatibility: <https://www.imsglobal.org/spec/lti-ags/v2p0#activityprogress>.
 */
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "activity_progress", rename_all = "snake_case")]
 pub enum ActivityProgress {
     /// The user has not started the activity, or the activity has been reset for that student.
@@ -73,7 +76,8 @@ Tells what's the status of the grading progress for a user and exercise.
 
 As close as possible LTI's grading progress for compatibility: <https://www.imsglobal.org/spec/lti-ags/v2p0#gradingprogress>
 */
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, sqlx::Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "grading_progress", rename_all = "kebab-case")]
 pub enum GradingProgress {
     /// The grading process is completed; the score value, if any, represents the current Final Grade;
@@ -94,7 +98,8 @@ impl GradingProgress {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseStatus {
     // None when grading has not completed yet. Max score can be found from the associated exercise.
     pub score_given: Option<f32>,

--- a/services/headless-lms/models/src/feedback.rs
+++ b/services/headless-lms/models/src/feedback.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewFeedback {
     pub feedback_given: String,
     pub selected_text: Option<String>,
@@ -8,7 +9,8 @@ pub struct NewFeedback {
     pub page_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct FeedbackBlock {
     pub id: Uuid,
     pub text: Option<String>,
@@ -69,7 +71,8 @@ WHERE id = $2
     Ok(())
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Feedback {
     pub id: Uuid,
     pub user_id: Option<Uuid>,
@@ -165,7 +168,8 @@ FROM (
     Ok(res)
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct FeedbackCount {
     pub read: u32,
     pub unread: u32,

--- a/services/headless-lms/models/src/glossary.rs
+++ b/services/headless-lms/models/src/glossary.rs
@@ -1,13 +1,15 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Term {
     pub id: Uuid,
     pub term: String,
     pub definition: String,
 }
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct TermUpdate {
     pub term: String,
     pub definition: String,

--- a/services/headless-lms/models/src/organizations.rs
+++ b/services/headless-lms/models/src/organizations.rs
@@ -16,7 +16,8 @@ pub struct DatabaseOrganization {
     pub deleted_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Organization {
     pub id: Uuid,
     pub slug: String,

--- a/services/headless-lms/models/src/page_history.rs
+++ b/services/headless-lms/models/src/page_history.rs
@@ -5,14 +5,16 @@ use crate::{
     prelude::*,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Type, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "history_change_reason", rename_all = "kebab-case")]
 pub enum HistoryChangeReason {
     PageSaved,
     HistoryRestored,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageHistory {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -23,7 +25,8 @@ pub struct PageHistory {
     pub author_user_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageHistoryContent {
     pub content: serde_json::Value,
     pub exercises: Vec<CmsPageExercise>,

--- a/services/headless-lms/models/src/pages.rs
+++ b/services/headless-lms/models/src/pages.rs
@@ -25,7 +25,8 @@ use crate::{
     CourseOrExamId,
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Page {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -48,7 +49,8 @@ impl Page {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CoursePageWithUserData {
     pub page: Page,
     pub instance: Option<CourseInstance>,
@@ -57,7 +59,8 @@ pub struct CoursePageWithUserData {
     pub was_redirected: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageWithExercises {
     #[serde(flatten)]
     pub page: Page,
@@ -65,7 +68,8 @@ pub struct PageWithExercises {
 }
 
 // Represents the subset of page fields that are required to create a new page.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewPage {
     pub exercises: Vec<CmsPageExercise>,
     pub exercise_slides: Vec<CmsPageExerciseSlide>,
@@ -83,7 +87,8 @@ pub struct NewPage {
     pub content_search_language: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NormalizedCmsExerciseTask {
     pub id: Uuid,
     pub exercise_type: String,
@@ -101,7 +106,8 @@ pub struct PageRoutingData {
     pub chapter_front_page_id: Option<Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageRoutingDataWithChapterStatus {
     pub url_path: String,
     pub title: String,
@@ -122,7 +128,8 @@ pub struct PageMetadata {
     exam_id: Option<Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageChapterAndCourseInformation {
     pub chapter_name: Option<String>,
     pub chapter_number: Option<i32>,
@@ -133,7 +140,8 @@ pub struct PageChapterAndCourseInformation {
     pub organization_slug: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageSearchResult {
     pub id: Uuid,
     pub title_headline: Option<String>,
@@ -142,7 +150,8 @@ pub struct PageSearchResult {
     pub url_path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ContentManagementPage {
     pub page: Page,
     pub exercises: Vec<CmsPageExercise>,
@@ -151,12 +160,14 @@ pub struct ContentManagementPage {
     pub organization_id: Uuid,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageSearchRequest {
     query: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseWithExerciseTasks {
     id: Uuid,
     created_at: DateTime<Utc>,
@@ -170,7 +181,8 @@ pub struct ExerciseWithExerciseTasks {
     score_maximum: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct HistoryRestoreData {
     pub history_id: Uuid,
 }
@@ -535,7 +547,8 @@ AND pages.deleted_at IS NULL
     Ok(res)
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CmsPageExercise {
     pub id: Uuid,
     pub name: String,
@@ -552,7 +565,8 @@ impl From<Exercise> for CmsPageExercise {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CmsPageExerciseSlide {
     pub id: Uuid,
     pub exercise_id: Uuid,
@@ -569,7 +583,8 @@ impl From<ExerciseSlide> for CmsPageExerciseSlide {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CmsPageExerciseTask {
     pub id: Uuid,
     pub exercise_slide_id: Uuid,
@@ -590,7 +605,8 @@ impl From<ExerciseTask> for CmsPageExerciseTask {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct CmsPageUpdate {
     pub content: serde_json::Value,
     pub exercises: Vec<CmsPageExercise>,

--- a/services/headless-lms/models/src/playground_examples.rs
+++ b/services/headless-lms/models/src/playground_examples.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PlaygroundExample {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -12,7 +13,8 @@ pub struct PlaygroundExample {
     pub data: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PlaygroundExampleData {
     pub name: String,
     pub url: String,

--- a/services/headless-lms/models/src/prelude.rs
+++ b/services/headless-lms/models/src/prelude.rs
@@ -5,6 +5,7 @@ pub use chrono::{DateTime, Utc};
 pub use headless_lms_utils::pagination::Pagination;
 pub use serde::{Deserialize, Serialize};
 pub use sqlx::{Connection, FromRow, PgConnection, Type};
+#[cfg(feature = "ts_rs")]
 pub use ts_rs::TS;
 pub use uuid::Uuid;
 

--- a/services/headless-lms/models/src/proposed_block_edits.rs
+++ b/services/headless-lms/models/src/proposed_block_edits.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewProposedBlockEdit {
     pub block_id: Uuid,
     pub block_attribute: String,
@@ -8,7 +9,8 @@ pub struct NewProposedBlockEdit {
     pub changed_text: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS, sqlx::Type)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, sqlx::Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "proposal_status", rename_all = "lowercase")]
 pub enum ProposalStatus {
     Pending,
@@ -16,7 +18,8 @@ pub enum ProposalStatus {
     Rejected,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct BlockProposal {
     pub id: Uuid,
     pub block_id: Uuid,
@@ -26,13 +29,15 @@ pub struct BlockProposal {
     pub accept_preview: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct BlockProposalInfo {
     pub id: Uuid,
     pub action: BlockProposalAction,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[serde(tag = "tag", content = "data")]
 pub enum BlockProposalAction {
     Accept(String),

--- a/services/headless-lms/models/src/proposed_page_edits.rs
+++ b/services/headless-lms/models/src/proposed_page_edits.rs
@@ -12,13 +12,15 @@ use crate::{
     },
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct NewProposedPageEdits {
     pub page_id: Uuid,
     pub block_edits: Vec<NewProposedBlockEdit>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct PageProposal {
     pub id: Uuid,
     pub page_id: Uuid,
@@ -30,14 +32,16 @@ pub struct PageProposal {
     pub page_url_path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct EditProposalInfo {
     pub page_id: Uuid,
     pub page_proposal_id: Uuid,
     pub block_proposals: Vec<BlockProposalInfo>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ProposalCount {
     pub pending: u32,
     pub handled: u32,

--- a/services/headless-lms/models/src/roles.rs
+++ b/services/headless-lms/models/src/roles.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Type, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Type)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[sqlx(type_name = "user_role", rename_all = "snake_case")]
 pub enum UserRole {
     Reviewer,
@@ -45,7 +46,8 @@ impl Role {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, TS)]
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[serde(tag = "tag", content = "id")]
 pub enum RoleDomain {
     Global,
@@ -55,7 +57,8 @@ pub enum RoleDomain {
     Exam(Uuid),
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct RoleUser {
     id: Uuid,
     first_name: Option<String>,

--- a/services/headless-lms/models/src/user_course_settings.rs
+++ b/services/headless-lms/models/src/user_course_settings.rs
@@ -1,6 +1,7 @@
 use crate::{course_instance_enrollments::CourseInstanceEnrollment, prelude::*};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct UserCourseSettings {
     pub user_id: Uuid,
     pub course_language_group_id: Uuid,

--- a/services/headless-lms/models/src/user_exercise_states.rs
+++ b/services/headless-lms/models/src/user_exercise_states.rs
@@ -69,7 +69,8 @@ impl TryFrom<UserExerciseState> for CourseInstanceOrExamId {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct UserCourseInstanceProgress {
     pub score_given: f32,
     pub score_maximum: Option<u32>,
@@ -77,7 +78,8 @@ pub struct UserCourseInstanceProgress {
     pub completed_exercises: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct UserCourseInstanceChapterExerciseProgress {
     pub exercise_id: Uuid,
     pub score_given: f32,
@@ -106,18 +108,19 @@ pub struct CourseInstanceExerciseMetrics {
     score_maximum: Option<i64>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, FromRow, PartialEq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseUserCounts {
     exercise_name: Option<String>,
     exercise_order_number: Option<i32>,
     page_order_number: Option<i32>,
     chapter_number: Option<i32>,
     exercise_id: Option<Uuid>,
-    #[ts(type = "number")]
+    #[cfg_attr(feature = "ts_rs", ts(type = "number"))]
     n_users_attempted: Option<i64>,
-    #[ts(type = "number")]
+    #[cfg_attr(feature = "ts_rs", ts(type = "number"))]
     n_users_with_some_points: Option<i64>,
-    #[ts(type = "number")]
+    #[cfg_attr(feature = "ts_rs", ts(type = "number"))]
     n_users_with_max_points: Option<i64>,
 }
 

--- a/services/headless-lms/models/src/users.rs
+++ b/services/headless-lms/models/src/users.rs
@@ -2,7 +2,8 @@ use headless_lms_utils::ApplicationConfiguration;
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct User {
     pub id: Uuid,
     pub first_name: Option<String>,

--- a/services/headless-lms/server/Cargo.toml
+++ b/services/headless-lms/server/Cargo.toml
@@ -87,7 +87,7 @@ ts-rs = { git = "https://github.com/Heliozoa/ts-rs", rev = "3d0fd4f71fd1698e4236
   "serde-compat",
   "serde-json-impl",
   "uuid-impl",
-] }
+], optional = true }
 # restricting the transitive dependencies of actix-web during beta.
 # HTTP primitives for the Actix ecosystem .
 actix-http = "3.0.3"
@@ -112,3 +112,6 @@ pretty_assertions = "1.1.0"
 mockito = "0.31.0"
 # Random number generators and other randomness functionality.
 rand = "0.8.5"
+
+[features]
+ts_rs = ["ts-rs"]

--- a/services/headless-lms/server/src/bin/doc-file-generator.rs
+++ b/services/headless-lms/server/src/bin/doc-file-generator.rs
@@ -54,6 +54,7 @@ use headless_lms_models::{
 };
 use serde::Serialize;
 use serde_json::{ser::PrettyFormatter, Serializer, Value};
+#[cfg(feature = "ts_rs")]
 use ts_rs::TS;
 use uuid::Uuid;
 
@@ -66,6 +67,7 @@ macro_rules! write_docs {
             stringify!($t),
             ".json"
         );
+        #[cfg(feature = "ts_rs")]
         let ts_path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/generated-docs/",
@@ -73,6 +75,7 @@ macro_rules! write_docs {
             ".ts"
         );
         write_json(json_path, t);
+        #[cfg(feature = "ts_rs")]
         write_ts::<$t>(ts_path, stringify!($t));
     }};
 }
@@ -792,6 +795,7 @@ fn write_json<T: Serialize>(path: &str, value: T) {
     serde::Serialize::serialize(&value, &mut serializer).unwrap();
 }
 
+#[cfg(feature = "ts_rs")]
 fn write_ts<T: TS>(path: &str, type_name: &str) {
     let contents = format!("type {} = {}", type_name, T::inline());
     std::fs::write(path, contents).unwrap();

--- a/services/headless-lms/server/src/controllers/auth.rs
+++ b/services/headless-lms/server/src/controllers/auth.rs
@@ -18,7 +18,8 @@ use url::form_urlencoded::Target;
 
 use crate::{controllers::prelude::*, domain::authorization, OAuthClient};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Login {
     email: String,
     password: String,

--- a/services/headless-lms/server/src/controllers/course_material/courses.rs
+++ b/services/headless-lms/server/src/controllers/course_material/courses.rs
@@ -124,7 +124,8 @@ async fn get_course_pages(
     Ok(web::Json(pages))
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ChaptersWithStatus {
     pub is_previewable: bool,
     pub chapters: Vec<ChapterWithStatus>,

--- a/services/headless-lms/server/src/controllers/course_material/exams.rs
+++ b/services/headless-lms/server/src/controllers/course_material/exams.rs
@@ -55,7 +55,8 @@ pub async fn enroll(
     ))
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExamData {
     pub id: Uuid,
     pub name: String,
@@ -67,7 +68,8 @@ pub struct ExamData {
     pub enrollment_data: ExamEnrollmentData,
 }
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[serde(tag = "tag")]
 pub enum ExamEnrollmentData {
     EnrolledAndStarted {

--- a/services/headless-lms/server/src/controllers/helpers/media.rs
+++ b/services/headless-lms/server/src/controllers/helpers/media.rs
@@ -14,7 +14,8 @@ use models::organizations::DatabaseOrganization;
 
 use crate::controllers::prelude::*;
 
-#[derive(Debug, Clone, Copy, Deserialize, TS)]
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub enum StoreKind {
     Organization(Uuid),
     Course(Uuid),

--- a/services/headless-lms/server/src/controllers/main_frontend/courses.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/courses.rs
@@ -429,7 +429,8 @@ async fn get_course_instances(
     Ok(web::Json(course_instances))
 }
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct GetFeedbackQuery {
     read: bool,
     #[serde(flatten)]

--- a/services/headless-lms/server/src/controllers/main_frontend/exams.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/exams.rs
@@ -25,7 +25,8 @@ pub async fn get_exam(
     Ok(web::Json(exam))
 }
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExamCourseInfo {
     course_id: Uuid,
 }

--- a/services/headless-lms/server/src/controllers/main_frontend/exercises.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/exercises.rs
@@ -5,7 +5,8 @@ use models::{exercise_slide_submissions::ExerciseSlideSubmission, CourseOrExamId
 
 use crate::controllers::prelude::*;
 
-#[derive(Debug, Serialize, TS)]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ExerciseSubmissions {
     pub data: Vec<ExerciseSlideSubmission>,
     pub total_pages: u32,

--- a/services/headless-lms/server/src/controllers/main_frontend/feedback.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/feedback.rs
@@ -2,7 +2,8 @@ use models::feedback;
 
 use crate::controllers::prelude::*;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct MarkAsRead {
     read: bool,
 }

--- a/services/headless-lms/server/src/controllers/main_frontend/proposed_edits.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/proposed_edits.rs
@@ -2,7 +2,8 @@ use models::proposed_page_edits::{self, EditProposalInfo, PageProposal, Proposal
 
 use crate::controllers::prelude::*;
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct GetEditProposalsQuery {
     pending: bool,
     #[serde(flatten)]

--- a/services/headless-lms/server/src/controllers/main_frontend/roles.rs
+++ b/services/headless-lms/server/src/controllers/main_frontend/roles.rs
@@ -5,7 +5,8 @@ use models::{
 
 use crate::controllers::prelude::*;
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct RoleInfo {
     pub email: String,
     pub role: UserRole,
@@ -80,7 +81,8 @@ pub async fn unset(
     Ok(HttpResponse::Ok().finish())
 }
 
-#[derive(Debug, Deserialize, TS)]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct RoleQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     global: Option<bool>,

--- a/services/headless-lms/server/src/controllers/mod.rs
+++ b/services/headless-lms/server/src/controllers/mod.rs
@@ -29,6 +29,7 @@ use headless_lms_models::ModelError;
 use headless_lms_utils::UtilError;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "ts_rs")]
 use ts_rs::TS;
 use uuid::Uuid;
 
@@ -65,14 +66,16 @@ pub enum ControllerError {
     Forbidden(String),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorData {
     BlockId(Uuid),
 }
 
 /// The format all error messages from the API is in
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct ErrorResponse {
     pub title: String,
     pub message: String,
@@ -196,7 +199,8 @@ Only put information here that you want to be visible to users.
 pub type ControllerResult<T, E = ControllerError> = std::result::Result<T, E>;
 
 /// Result of a image upload. Tells where the uploaded image can be retrieved from.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TS)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct UploadResult {
     pub url: String,
 }

--- a/services/headless-lms/server/src/controllers/prelude.rs
+++ b/services/headless-lms/server/src/controllers/prelude.rs
@@ -15,5 +15,6 @@ pub use headless_lms_utils::{
 };
 pub use serde::{Deserialize, Serialize};
 pub use sqlx::{Connection, FromRow, PgConnection, PgPool, Type};
+#[cfg(feature = "ts_rs")]
 pub use ts_rs::TS;
 pub use uuid::Uuid;

--- a/services/headless-lms/server/src/ts_binding_generator.rs
+++ b/services/headless-lms/server/src/ts_binding_generator.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "ts_rs")]
 use crate::controllers::{
     auth::Login,
     course_material::{
@@ -14,15 +15,19 @@ use crate::controllers::{
     },
     ErrorData, ErrorResponse, UploadResult,
 };
+#[cfg(feature = "ts_rs")]
 use headless_lms_models::*;
+#[cfg(feature = "ts_rs")]
 use headless_lms_utils::pagination::Pagination;
 
+#[cfg(feature = "ts_rs")]
 macro_rules! export {
     ($target:expr, $($types:ty),*) => {
         {
             let target = $target;
             fn _export(target: &mut impl ::std::io::Write) -> ::std::result::Result<(), ::std::io::Error> {
                 $(
+                    #[cfg(feature = "ts_rs")]
                     writeln!(target, "export {}\n", <$types as ::ts_rs::TS>::decl())?;
                 )*
                 Ok(())
@@ -33,6 +38,7 @@ macro_rules! export {
 }
 
 #[test]
+#[cfg(feature = "ts_rs")]
 fn ts_binding_generator() {
     let mut target = std::fs::File::create("../../../shared-module/src/bindings.ts").unwrap();
     let res = export! {

--- a/services/headless-lms/utils/Cargo.toml
+++ b/services/headless-lms/utils/Cargo.toml
@@ -51,7 +51,7 @@ ts-rs = { git = "https://github.com/Heliozoa/ts-rs", rev = "3d0fd4f71fd1698e4236
   "serde-compat",
   "serde-json-impl",
   "uuid-impl",
-] }
+], optional = true }
 # An implementation of regular expressions for Rust.
 regex = "1.5.5"
 # Single assignment cells and lazy values.
@@ -67,3 +67,6 @@ indexmap = "1.6.2"
 [dev-dependencies]
 # Overwrite `assert_eq!` and `assert_ne!` with drop-in replacements, adding colorful diffs.
 pretty_assertions = "1.1.0"
+
+[features]
+ts_rs = ["ts-rs"]

--- a/services/headless-lms/utils/src/pagination.rs
+++ b/services/headless-lms/utils/src/pagination.rs
@@ -4,16 +4,18 @@ use serde::{
     de::{self, MapAccess, Visitor},
     Deserialize, Deserializer,
 };
+#[cfg(feature = "ts_rs")]
 use ts_rs::TS;
 
 /// Represents the URL query parameters `page` and `limit`, used for paginating database queries.
-#[derive(Debug, Clone, Copy, TS)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "ts_rs", derive(TS))]
 pub struct Pagination {
     // the deserialize implementation contains a default value for page
-    #[ts(rename = "page?")]
+    #[cfg_attr(feature = "ts_rs", ts(rename = "page?"))]
     page: u32,
     // the deserialize implementation contains a default value for limit
-    #[ts(rename = "limit?")]
+    #[cfg_attr(feature = "ts_rs", ts(rename = "limit?"))]
     limit: u32,
 }
 


### PR DESCRIPTION
This reduces the lines sent to LLVM in the models crate by `(499516 − 264509) / 499516 ≈ 0.4704694144`.

Measured with `env CARGO_PROFILE_RELEASE_LTO=fat cargo llvm-lines --release` in the models folder.

This hopefully improves compilation times.