### PR TITLE
Downgrade lint-staged to 12.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "secret-project-331",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -28,7 +27,7 @@
         "eslint-plugin-react-hooks": "^4.5.0",
         "husky": "^8.0.1",
         "i18next-parser": "^6.4.0",
-        "lint-staged": "^12.4.1",
+        "lint-staged": "^12.3.8",
         "postcss-syntax": "^0.36.2",
         "prettier": "^2.6.2",
         "stylelint": "^14.8.2",
@@ -4456,9 +4455,9 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.4.1.tgz",
-      "integrity": "sha512-PTXgzpflrQ+pODQTG116QNB+Q6uUTDg5B5HqGvNhoQSGt8Qy+MA/6zSnR8n38+sxP5TapzeQGTvoKni0KRS8Vg==",
+      "version": "12.3.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.8.tgz",
+      "integrity": "sha512-0+UpNaqIwKRSGAFOCcpuYNIv/j5QGVC+xUVvmSdxHO+IfIGoHbFLo3XcPmV/LLnsVj5EAncNHVtlITSoY5qWGQ==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^3.1.0",
@@ -10708,9 +10707,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.4.1.tgz",
-      "integrity": "sha512-PTXgzpflrQ+pODQTG116QNB+Q6uUTDg5B5HqGvNhoQSGt8Qy+MA/6zSnR8n38+sxP5TapzeQGTvoKni0KRS8Vg==",
+      "version": "12.3.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.8.tgz",
+      "integrity": "sha512-0+UpNaqIwKRSGAFOCcpuYNIv/j5QGVC+xUVvmSdxHO+IfIGoHbFLo3XcPmV/LLnsVj5EAncNHVtlITSoY5qWGQ==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-react-hooks": "^4.5.0",
     "husky": "^8.0.1",
     "i18next-parser": "^6.4.0",
-    "lint-staged": "^12.4.1",
+    "lint-staged": "^12.3.8",
     "postcss-syntax": "^0.36.2",
     "prettier": "^2.6.2",
     "stylelint": "^14.8.2",


### PR DESCRIPTION
Solves issue with precommit hook failing to detect any files.