### PR TITLE
Create intermediate directories in local file storage

### DIFF
--- a/services/headless-lms/utils/src/file_store/local_file_store.rs
+++ b/services/headless-lms/utils/src/file_store/local_file_store.rs
@@ -43,6 +43,9 @@ impl FileStore for LocalFileStore {
         _mime_type: &str,
     ) -> Result<(), UtilError> {
         let full_path = self.base_path.join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
         fs::write(full_path, contents).await?;
         Ok(())
     }


### PR DESCRIPTION
Currently an error is returned when trying to create a file `a/b` where `a` doesn't exist.