### PR TITLE
use id if provided for error-identification

### DIFF
--- a/shared-module/src/components/InputFields/CheckBox.tsx
+++ b/shared-module/src/components/InputFields/CheckBox.tsx
@@ -14,6 +14,7 @@ interface CheckboxFieldExtraProps {
   onChange?: (checked: boolean, name?: string) => void
   className?: string
   register?: UseFormRegisterReturn
+  id?: string
 }
 
 const ERRORCOLOR = "#F76D82"
@@ -124,7 +125,7 @@ const CheckBox = ({ onChange, className, checked, register, ...rest }: CheckboxF
                   display: block;
                 `
           }
-          id={`${rest.label}_error`}
+          id={`${rest.id ?? rest.label}_error`}
           role="alert"
         >
           {ERROR}

--- a/shared-module/src/components/InputFields/TextField.tsx
+++ b/shared-module/src/components/InputFields/TextField.tsx
@@ -127,7 +127,7 @@ const TextField = ({ onChange, className, register, disabled, ...rest }: TextFie
                 visibility: hidden;
               `
         }
-        id={`${rest.label}_error`}
+        id={`${rest.id ?? rest.label}_error`}
         role="alert"
       >
         {rest.error}


### PR DESCRIPTION
This fixes the accessibility check error on a list of these components with identical labels.