### PR TITLE
Instruct Mac users to install coreutils to be able to run some scripts

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -203,10 +203,10 @@ You may also need:
 1. [Stern](https://github.com/wercker/stern)
 2. [Kubectx](https://github.com/ahmetb/kubectx)
 
-In addition, you need the commands (`bc, find, jq, rsync, sponge`) for the scripts:
+In addition, you need the commands (`bc, find, jq, rsync, sponge, realpath`) for the scripts:
 
 ```
-brew install bc jq rsync sponge
+brew install bc jq rsync sponge coreutils
 ```
 
 You may also need stern and kubectx:


### PR DESCRIPTION
At least [copy-and-check-shared-module](https://github.com/rage/secret-project-331/blob/4e83fd999bcb8589b16a96889a6413fb06a98398/bin/copy-and-check-shared-module#L7) requires the `realpath` utility, which isn't present on macOS by default, so added `coreutils` to the suggested list of brew packages to install