### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,5 @@ jobs:
         run: npm run eslint:ci
       - name: Stylelint
         run: npm run lint:css
-      - name: Update rust to get edition 2021 support
-        run: rustup update stable
       - name: Cargo fmt
         run: cargo fmt --manifest-path services/headless-lms/Cargo.toml --all -- --files-with-diff --check

--- a/bin/update-dependencies-part-1
+++ b/bin/update-dependencies-part-1
@@ -57,7 +57,6 @@ update_node_deps "$RELATIVE_PATH/services/tmc" "tmc"
 update_node_deps "$RELATIVE_PATH/shared-module" "shared-module"
 
 # Update rust deps
-run_command bin/update-rust
 run_command cd services/headless-lms
 run_command cargo upgrade --incompatible allow --pinned allow --recursive true
 if [[ $(git status --porcelain) ]]; then

--- a/bin/update-rust
+++ b/bin/update-rust
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-source "$(dirname "$0")/.common"
-
-run_command rustup update

--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -27,8 +27,6 @@ Start by upgrading the dependencies in the root of the repo and run `npm run esl
 
 ## Update rust dependencies
 
-1. Run `bin/update-rust`
-
 Make sure you have [cargo-edit](https://github.com/killercup/cargo-edit) installed. After that, run the following commands:
 
 ```bash

--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -27,6 +27,8 @@ Start by upgrading the dependencies in the root of the repo and run `npm run esl
 
 ## Update rust dependencies
 
+Update the `channel` in `rust-toolchain.toml` to the latest stable version (https://forge.rust-lang.org/).
+
 Make sure you have [cargo-edit](https://github.com/killercup/cargo-edit) installed. After that, run the following commands:
 
 ```bash

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.75"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.75"
+profile = "default"


### PR DESCRIPTION
This would allow us to have all developers use the same Rust version, and for us to update everyone's Rust version along with other dependency updates

Other notes:

I left out the patch version. https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file makes it look like you must specify the patch version, but it works with just major.minor. We could also specify the patch version or even use `channel = "stable"` and it would probably be fine.

The file could be moved to `services/headless-lms` if preferred, since all the Rust crates are in there at the moment.

The default profile ensures rustfmt, clippy and rustdoc are installed.

I removed update-rust and the rustup update call from CI since the toolchain file handles that automatically whenever cargo is called.