### PR TITLE
Remove npm ci from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Secret Project 331
-
-Before you start working on this project, please run `npm ci` in the repo root.
-
 ## Development environment setup
 
 Read [Development.md](https://github.com/rage/secret-project-331/blob/master/docs/Development.md) on how to setup using Windows or Linux.


### PR DESCRIPTION
Remove `npm ci` from README since all development instructions are in Development.md and `npm ci ` should not be run before checking the Development.md since f.ex. rsync is needed.

![kuva](https://github.com/rage/secret-project-331/assets/31825085/0be2ffe2-8d1c-4440-8413-12d972507f76)
