### PR TITLE
Make marking completions as registered not to crash if a completion has been deleted before the marking has succeeded

### DIFF
--- a/services/headless-lms/models/.sqlx/query-d33b4857d2fddb3611d4ad17ea527321c55f43c5c1d3aadc646876b41b1beb01.json
+++ b/services/headless-lms/models/.sqlx/query-d33b4857d2fddb3611d4ad17ea527321c55f43c5c1d3aadc646876b41b1beb01.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT *\nFROM course_module_completions\nWHERE id = ANY($1)\n  AND deleted_at IS NULL\n        ",
+  "query": "\nSELECT *\nFROM course_module_completions\nWHERE id = ANY($1)\n        ",
   "describe": {
     "columns": [
       {
@@ -118,5 +118,5 @@
       true
     ]
   },
-  "hash": "33f56f379b3a6a63426f90dfec33fe0938212dba397aafd2581193b93c05dcb2"
+  "hash": "d33b4857d2fddb3611d4ad17ea527321c55f43c5c1d3aadc646876b41b1beb01"
 }

--- a/services/headless-lms/models/src/course_module_completions.rs
+++ b/services/headless-lms/models/src/course_module_completions.rs
@@ -158,6 +158,7 @@ WHERE id = $1
     Ok(res)
 }
 
+/// Also returns soft deleted completions so that we can make sure the process does not crash if a completion is deleted before we get it back from the study registry.
 pub async fn get_by_ids(
     conn: &mut PgConnection,
     ids: &[Uuid],
@@ -168,7 +169,6 @@ pub async fn get_by_ids(
 SELECT *
 FROM course_module_completions
 WHERE id = ANY($1)
-  AND deleted_at IS NULL
         ",
         ids,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated query to retrieve course module completions, now including soft-deleted records to prevent potential retrieval process interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->