### PR TITLE
Default to blocks not allowing wider content inside innerblocks

### DIFF
--- a/services/cms/tsconfig.json
+++ b/services/cms/tsconfig.json
@@ -21,5 +21,5 @@
     "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/shared-module"]
 }

--- a/services/course-material/src/components/ContentRenderer/index.tsx
+++ b/services/course-material/src/components/ContentRenderer/index.tsx
@@ -196,16 +196,24 @@ const defaultBlockMargin = css`
   margin: ${COURSE_MATERIAL_DEFAULT_BLOCK_MARGIN_REM}rem 0;
 `
 
-const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> = (props) => {
+const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> = ({
+  data,
+  editing,
+  selectedBlockId,
+  setEdits,
+  isExam,
+  dontAddWrapperDivMeantForMostOutermostContentRenderer,
+  dontAllowBlockToBeWiderThanContainerWidth = true,
+}) => {
   const highlightBlocks = useQueryParameter("highlight-blocks")
     .split(",")
     .filter((id) => id !== "")
   const { t } = useTranslation()
-  if (props.data.constructor !== Array) {
+  if (data.constructor !== Array) {
     return (
       <div>
         <p>{t("error-page-data-in-invalid-format")}</p>
-        <pre>{JSON.stringify(props.data, undefined, 2)}</pre>
+        <pre>{JSON.stringify(data, undefined, 2)}</pre>
       </div>
     )
   }
@@ -249,7 +257,7 @@ const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> =
 
   const content = (
     <>
-      {props.data.map((block) => {
+      {data.map((block) => {
         const Component = blockToRendererMap[block.name] ?? DefaultBlock
         const isHighlighted = highlightBlocks.includes(block.clientId)
         const dontUseDefaultBlockMargin = Component.dontUseDefaultBlockMargin === true
@@ -269,14 +277,12 @@ const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> =
               key={block.clientId}
               id={block.clientId}
               data={block}
-              editing={props.editing}
-              selectedBlockId={props.selectedBlockId}
-              setEdits={props.setEdits}
-              isExam={props.isExam}
+              editing={editing}
+              selectedBlockId={selectedBlockId}
+              setEdits={setEdits}
+              isExam={isExam}
               wrapperClassName={wrapperClassName}
-              dontAllowBlockToBeWiderThanContainerWidth={
-                props.dontAllowBlockToBeWiderThanContainerWidth
-              }
+              dontAllowBlockToBeWiderThanContainerWidth={dontAllowBlockToBeWiderThanContainerWidth}
             />
           )
         }
@@ -286,14 +292,12 @@ const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> =
             <Component
               id={block.clientId}
               data={block}
-              editing={props.editing}
-              selectedBlockId={props.selectedBlockId}
-              setEdits={props.setEdits}
-              isExam={props.isExam}
+              editing={editing}
+              selectedBlockId={selectedBlockId}
+              setEdits={setEdits}
+              isExam={isExam}
               wrapperClassName={wrapperClassName}
-              dontAllowBlockToBeWiderThanContainerWidth={
-                props.dontAllowBlockToBeWiderThanContainerWidth
-              }
+              dontAllowBlockToBeWiderThanContainerWidth={dontAllowBlockToBeWiderThanContainerWidth}
             />
           </div>
         )
@@ -301,19 +305,15 @@ const ContentRenderer: React.FC<React.PropsWithChildren<ContentRendererProps>> =
     </>
   )
 
-  if (props.dontAddWrapperDivMeantForMostOutermostContentRenderer) {
+  if (dontAddWrapperDivMeantForMostOutermostContentRenderer) {
     return (
-      <BreakFromCenteredDisabledContext.Provider
-        value={props.dontAllowBlockToBeWiderThanContainerWidth ?? false}
-      >
+      <BreakFromCenteredDisabledContext.Provider value={dontAllowBlockToBeWiderThanContainerWidth}>
         {content}
       </BreakFromCenteredDisabledContext.Provider>
     )
   }
   return (
-    <BreakFromCenteredDisabledContext.Provider
-      value={props.dontAllowBlockToBeWiderThanContainerWidth ?? false}
-    >
+    <BreakFromCenteredDisabledContext.Provider value={dontAllowBlockToBeWiderThanContainerWidth}>
       <div
         className={css`
           font-size: 20px;

--- a/services/course-material/src/components/ContentRenderer/moocfi/ConditionalBlock.tsx
+++ b/services/course-material/src/components/ContentRenderer/moocfi/ConditionalBlock.tsx
@@ -40,7 +40,16 @@ const ConditionalBlock: React.FC<
     (userSettings?.current_course_instance_id &&
       enrollmentsRequired.some((x) => x == userSettings.current_course_instance_id))
 
-  return <>{completionMet && enrollmentMet && <InnerBlocks parentBlockProps={props} />}</>
+  return (
+    <>
+      {completionMet && enrollmentMet && (
+        <InnerBlocks
+          parentBlockProps={props}
+          dontAllowInnerBlocksToBeWiderThanParentBlock={false}
+        />
+      )}
+    </>
+  )
 }
 
 export default ConditionalBlock

--- a/services/course-material/src/components/ContentRenderer/util/InnerBlocks.tsx
+++ b/services/course-material/src/components/ContentRenderer/util/InnerBlocks.tsx
@@ -7,17 +7,24 @@ import withErrorBoundary from "@/shared-module/common/utils/withErrorBoundary"
 interface InnerBlocksProps {
   /** For convinience, this takes the props from the parent block directly  */
   parentBlockProps: BlockRendererProps<unknown>
+  /** If true, the inner blocks will not be allowed to be wider than the parent block */
+  dontAllowInnerBlocksToBeWiderThanParentBlock?: boolean
 }
 
 /** An implementation on how to render inner blocks in the course material  */
-const InnerBlocks: React.FC<React.PropsWithChildren<InnerBlocksProps>> = ({ parentBlockProps }) => {
+const InnerBlocks: React.FC<React.PropsWithChildren<InnerBlocksProps>> = ({
+  parentBlockProps,
+  dontAllowInnerBlocksToBeWiderThanParentBlock = true,
+}) => {
   const { data, id: _id, ...rest } = parentBlockProps
   return (
     <ContentRenderer
       data={data.innerBlocks}
       {...rest}
       /// The wrapper div providing styles must be skipped for innerblocks because list block's inner blocks cannot contain any div elements. See: https://dequeuniversity.com/rules/axe/4.4/list
-      dontAddWrapperDivMeantForMostOutermostContentRenderer
+      dontAddWrapperDivMeantForMostOutermostContentRenderer={
+        dontAllowInnerBlocksToBeWiderThanParentBlock
+      }
     />
   )
 }

--- a/services/course-material/src/components/Page.tsx
+++ b/services/course-material/src/components/Page.tsx
@@ -249,6 +249,7 @@ const Page: React.FC<React.PropsWithChildren<Props>> = ({ onRefresh, organizatio
               selectedBlockId={selectedBlockId}
               setEdits={setEdits}
               isExam={pageContext.exam !== null}
+              dontAllowBlockToBeWiderThanContainerWidth={false}
             />
           </div>
         </div>

--- a/services/course-material/src/pages/[organizationSlug]/exams/[id].tsx
+++ b/services/course-material/src/pages/[organizationSlug]/exams/[id].tsx
@@ -225,6 +225,7 @@ const Exam: React.FC<React.PropsWithChildren<ExamProps>> = ({ query }) => {
                 selectedBlockId={null}
                 setEdits={(map) => map}
                 isExam={false}
+                dontAllowBlockToBeWiderThanContainerWidth={false}
               />
             </div>
           </ExamStartBanner>

--- a/services/course-material/src/pages/[organizationSlug]/exams/testexam/[id].tsx
+++ b/services/course-material/src/pages/[organizationSlug]/exams/testexam/[id].tsx
@@ -268,6 +268,7 @@ const Exam: React.FC<React.PropsWithChildren<ExamProps>> = ({ query }) => {
                 selectedBlockId={null}
                 setEdits={(map) => map}
                 isExam={false}
+                dontAllowBlockToBeWiderThanContainerWidth={false}
               />
             </div>
           </ExamStartBanner>

--- a/services/course-material/tsconfig.json
+++ b/services/course-material/tsconfig.json
@@ -26,7 +26,7 @@
     "isolatedModules": true,
     "incremental": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/shared-module"],
   "include": [
     "next-env.d.ts",
     "katex.d.ts",

--- a/services/example-exercise/tsconfig.json
+++ b/services/example-exercise/tsconfig.json
@@ -25,6 +25,6 @@
     "isolatedModules": true,
     "incremental": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/shared-module"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/services/main-frontend/tsconfig.json
+++ b/services/main-frontend/tsconfig.json
@@ -25,5 +25,5 @@
     "**/*.tsx",
     "../cms/src/components/forms/NewResearchConsentForm.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/shared-module"]
 }

--- a/services/quizzes/tsconfig.json
+++ b/services/quizzes/tsconfig.json
@@ -29,6 +29,6 @@
     "strictNullChecks": true,
     "incremental": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/shared-module"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/pages/_app.tsx"]
 }

--- a/services/tmc/tsconfig.json
+++ b/services/tmc/tsconfig.json
@@ -26,6 +26,6 @@
     "isolatedModules": true,
     "incremental": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/shared-module"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/shared-module/packages/common/tsconfig.json
+++ b/shared-module/packages/common/tsconfig.json
@@ -22,6 +22,6 @@
     "isolatedModules": false,
     "jsxImportSource": "@emotion/react"
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/shared-module"],
   "include": ["env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -25,5 +25,5 @@
     "**/*.tsx",
     "../cms/src/components/forms/NewResearchConsentForm.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/shared-module"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced layout customization: Content blocks now offer flexible width settings on course materials and exam pages, allowing displays to extend beyond container boundaries when appropriate.
  
- **Refactor**
  - Streamlined the handling of component properties for improved readability and maintainability without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->