### PR TITLE
Fix InnerBlocks block width handling

### DIFF
--- a/services/course-material/src/components/ContentRenderer/util/InnerBlocks.tsx
+++ b/services/course-material/src/components/ContentRenderer/util/InnerBlocks.tsx
@@ -22,9 +22,8 @@ const InnerBlocks: React.FC<React.PropsWithChildren<InnerBlocksProps>> = ({
       data={data.innerBlocks}
       {...rest}
       /// The wrapper div providing styles must be skipped for innerblocks because list block's inner blocks cannot contain any div elements. See: https://dequeuniversity.com/rules/axe/4.4/list
-      dontAddWrapperDivMeantForMostOutermostContentRenderer={
-        dontAllowInnerBlocksToBeWiderThanParentBlock
-      }
+      dontAddWrapperDivMeantForMostOutermostContentRenderer
+      dontAllowBlockToBeWiderThanContainerWidth={dontAllowInnerBlocksToBeWiderThanParentBlock}
     />
   )
 }


### PR DESCRIPTION
- Update InnerBlocks to correctly pass the dontAllowBlockToBeWiderThanContainerWidth prop, enhancing control over inner block widths.
- Remove redundant prop to streamline the component's functionality.