### PR TITLE
Allow teaching and learning services to view stats

### DIFF
--- a/services/headless-lms/server/src/domain/authorization.rs
+++ b/services/headless-lms/server/src/domain/authorization.rs
@@ -680,7 +680,10 @@ fn has_permission(user_role: UserRole, action: Action) -> bool {
         TeachingAndLearningServices => {
             matches!(
                 action,
-                View | ViewMaterial | ViewUserProgressOrDetails | ViewInternalCourseStructure
+                View | ViewMaterial
+                    | ViewUserProgressOrDetails
+                    | ViewInternalCourseStructure
+                    | ViewStats
             )
         }
         StatsViewer => matches!(action, ViewStats),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users with the Teaching and Learning Services role can now access course statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->