### PR TITLE
Add pull-images to minikube-start

### DIFF
--- a/bin/minikube-start
+++ b/bin/minikube-start
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-source "$(dirname "$0")/.common"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "${SCRIPT_DIR}/.common"
 
 trap 'echo -e "\n${RED}Error: Something went wrong while starting minikube. You can run ${CURSIVE}bin/detect-dev-env-problems${RESET_EVERYTHING}${RED} to detect some common problems.${RESET_EVERYTHING}"' ERR
 
@@ -52,5 +53,8 @@ fi
 run_command "$COMMAND" "${ARGUMENTS[@]}"
 # Have to update the config for the ingress to that the ingress controller does not reject our ingresses
 run_command kubectl patch configmap ingress-nginx-controller -p '{"data":{"allow-snippet-annotations":"true"}}' -n ingress-nginx --type merge
+
+run_command "$SCRIPT_DIR/minikube-pull-images"
+
 echo ""
 echo -e "${GREEN}✅ Minikube has been started. You can now use ${CURSIVE}bin/dev${RESET_EVERYTHING}${GREEN}, ${CURSIVE}bin/dev-only-db${RESET_EVERYTHING}${GREEN}, or ${CURSIVE}bin/test${RESET_EVERYTHING}${GREEN}.${RESET_EVERYTHING}"


### PR DESCRIPTION
Looks like this when ran

<img width="1619" height="965" alt="image" src="https://github.com/user-attachments/assets/d5a1f5b0-2ea0-435a-adf2-0030925f4517" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local development startup now pulls required container images as part of the flow.
  - Displays a clear success message after startup with suggested next commands (dev, db-only, test).

- **Chores**
  - Improves reliability of the startup process and helper execution.
  - Minor output formatting tweaks for readability (extra spacing before the success message).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->