### PR TITLE
Fix getting multiple grading decision returning old decisions sometimes

### DIFF
--- a/services/headless-lms/models/.sqlx/query-332f207786e607bdf65df714ed797932f9370e3f01b6091e829202860101b290.json
+++ b/services/headless-lms/models/.sqlx/query-332f207786e607bdf65df714ed797932f9370e3f01b6091e829202860101b290.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT id,\n  user_exercise_state_id,\n  created_at,\n  updated_at,\n  deleted_at,\n  score_given,\n  teacher_decision AS \"teacher_decision: _\",\n  justification,\n  hidden\nFROM teacher_grading_decisions\nWHERE user_exercise_state_id IN (\n    SELECT UNNEST($1::uuid [])\n  )\n  AND deleted_at IS NULL\n      ",
+  "query": "\nSELECT DISTINCT ON (user_exercise_state_id) id,\n  user_exercise_state_id,\n  created_at,\n  updated_at,\n  deleted_at,\n  score_given,\n  teacher_decision AS \"teacher_decision: _\",\n  justification,\n  hidden\nFROM teacher_grading_decisions\nWHERE user_exercise_state_id = ANY($1)\n  AND deleted_at IS NULL\nORDER BY user_exercise_state_id,\n  created_at DESC\n      ",
   "describe": {
     "columns": [
       {
@@ -61,5 +61,5 @@
     },
     "nullable": [false, false, false, false, true, false, false, true, false]
   },
-  "hash": "bb20c102c5a6481cdf1ad59df6f2037ca952fd12c1adfb2407e59fa1bc896b99"
+  "hash": "332f207786e607bdf65df714ed797932f9370e3f01b6091e829202860101b290"
 }

--- a/services/headless-lms/models/src/teacher_grading_decisions.rs
+++ b/services/headless-lms/models/src/teacher_grading_decisions.rs
@@ -116,7 +116,7 @@ pub async fn try_to_get_latest_grading_decision_by_user_exercise_state_id_for_us
     let decisions = sqlx::query_as!(
         TeacherGradingDecision,
         r#"
-SELECT id,
+SELECT DISTINCT ON (user_exercise_state_id) id,
   user_exercise_state_id,
   created_at,
   updated_at,
@@ -126,10 +126,10 @@ SELECT id,
   justification,
   hidden
 FROM teacher_grading_decisions
-WHERE user_exercise_state_id IN (
-    SELECT UNNEST($1::uuid [])
-  )
+WHERE user_exercise_state_id = ANY($1)
   AND deleted_at IS NULL
+ORDER BY user_exercise_state_id,
+  created_at DESC
       "#,
         user_exercise_state_ids,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the latest teacher grading decision is consistently returned per exercise attempt, removing duplicate or out-of-order entries in grading views, reports, and APIs.

* **Performance**
  * Improves filtering logic for multi-item queries, reducing redundant work and improving query efficiency and response times for grading-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->