### PR TITLE
Add migration scripts to enforce unique constraints on user_course_ex…

### DIFF
--- a/services/headless-lms/migrations/20250910111258_add_new_contstraint_for_user_course_exercise_service_variables.down.sql
+++ b/services/headless-lms/migrations/20250910111258_add_new_contstraint_for_user_course_exercise_service_variables.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_course_exercise_service_variables DROP CONSTRAINT no_duplicate_keys_course;

--- a/services/headless-lms/migrations/20250910111258_add_new_contstraint_for_user_course_exercise_service_variables.up.sql
+++ b/services/headless-lms/migrations/20250910111258_add_new_contstraint_for_user_course_exercise_service_variables.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE user_course_exercise_service_variables
+ADD CONSTRAINT no_duplicate_keys_course UNIQUE NULLS NOT DISTINCT (
+    variable_key,
+    user_id,
+    course_id,
+    exercise_service_slug,
+    exam_id,
+    deleted_at
+  );


### PR DESCRIPTION
…ercise_service_variables

- Created 'up' migration to add a unique constraint on variable_key, user_id, course_id, exercise_service_slug, exam_id, and deleted_at.
- Created 'down' migration to remove the unique constraint if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate exercise service variable entries for the same user, course, exam, and service, reducing inconsistent behavior and conflicts.
  * Improves data integrity so results remain predictable when creating or updating variables, including cases with empty values.

* **Chores**
  * Introduced a database-level uniqueness rule to enforce the above improvements.
  * Included a reversible migration to safely apply or roll back the constraint as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->