### PR TITLE
Use ubicloud-standard-30 for building and running system tests

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   labels:
-    - ubicloud-standard-16
+    - ubicloud-standard-30

--- a/.github/workflows/system-tests-and-deploy.yml
+++ b/.github/workflows/system-tests-and-deploy.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-and-system-tests:
-    runs-on: ubicloud-standard-16
+    runs-on: ubicloud-standard-30
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI infrastructure updated to use higher-capacity self-hosted runners for build, system test, and deployment workflows.
  * Expected improvements: faster pipeline throughput, reduced queue times, and increased stability under heavy workloads.
  * No changes to product functionality, user experience, or APIs.
  * No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->