### PR TITLE
Switch to 24.04 on system tests and deploy

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   labels:
-    - ubicloud-standard-30
+    - ubicloud-standard-30-ubuntu-2404

--- a/.github/workflows/system-tests-and-deploy.yml
+++ b/.github/workflows/system-tests-and-deploy.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-and-system-tests:
-    runs-on: ubicloud-standard-30
+    runs-on: ubicloud-standard-30-ubuntu-2404
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration runner environment to Ubuntu 24.04 for system tests and linting to improve reliability, consistency, and compatibility with modern toolchains.
  * No changes to workflow steps or application behavior; builds, tests, and deployments run as before.
  * No user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->