### PR TITLE
Allow switching languages when the current page is not in the other language version

### DIFF
--- a/services/headless-lms/models/src/courses.rs
+++ b/services/headless-lms/models/src/courses.rs
@@ -115,21 +115,25 @@ pub struct CourseLanguageVersionNavigationInfo {
     pub course_slug: String,
     pub page_path: String,
     pub is_draft: bool,
+    pub current_page_unavailable_in_this_language: bool,
 }
 
 impl CourseLanguageVersionNavigationInfo {
     /// Creates a new `CourseLanguageVersionNavigationInfo` from a course and page language group navigation info.
     pub fn from_course_and_page_info(
         course: &Course,
-        page_info: &crate::page_language_groups::PageLanguageGroupNavigationInfo,
+        page_info: Option<&crate::page_language_groups::PageLanguageGroupNavigationInfo>,
     ) -> Self {
         Self {
             course_language_group_id: course.course_language_group_id,
             course_id: course.id,
             language_code: course.language_code.clone(),
             course_slug: course.slug.clone(),
-            page_path: page_info.page_path.clone(),
+            page_path: page_info
+                .map(|p| p.page_path.clone())
+                .unwrap_or_else(|| "/".to_string()),
             is_draft: course.is_draft,
+            current_page_unavailable_in_this_language: page_info.is_none(),
         }
     }
 }

--- a/services/headless-lms/server/src/controllers/course_material/courses.rs
+++ b/services/headless-lms/server/src/controllers/course_material/courses.rs
@@ -740,15 +740,13 @@ async fn get_all_course_language_versions_navigation_info_from_page(
     token.authorized_ok(web::Json(
         accessible_courses
             .into_iter()
-            .filter_map(|c| {
-                all_pages_in_same_page_language_group
-                    .get(&CourseOrExamId::Course(c.id))
-                    .map(|page_language_group_navigation_info| {
-                        CourseLanguageVersionNavigationInfo::from_course_and_page_info(
-                            &c,
-                            page_language_group_navigation_info,
-                        )
-                    })
+            .map(|c| {
+                let page_language_group_navigation_info =
+                    all_pages_in_same_page_language_group.get(&CourseOrExamId::Course(c.id));
+                CourseLanguageVersionNavigationInfo::from_course_and_page_info(
+                    &c,
+                    page_language_group_navigation_info,
+                )
             })
             .collect(),
     ))

--- a/shared-module/packages/common/src/bindings.guard.ts
+++ b/shared-module/packages/common/src/bindings.guard.ts
@@ -1315,7 +1315,8 @@ export function isCourseLanguageVersionNavigationInfo(obj: unknown): obj is Cour
         typeof typedObj["language_code"] === "string" &&
         typeof typedObj["course_slug"] === "string" &&
         typeof typedObj["page_path"] === "string" &&
-        typeof typedObj["is_draft"] === "boolean"
+        typeof typedObj["is_draft"] === "boolean" &&
+        typeof typedObj["current_page_unavailable_in_this_language"] === "boolean"
     )
 }
 

--- a/shared-module/packages/common/src/bindings.ts
+++ b/shared-module/packages/common/src/bindings.ts
@@ -636,6 +636,7 @@ export interface CourseLanguageVersionNavigationInfo {
   course_slug: string
   page_path: string
   is_draft: boolean
+  current_page_unavailable_in_this_language: boolean
 }
 
 export interface EmailTemplate {

--- a/shared-module/packages/common/src/locales/ar/course-material.json
+++ b/shared-module/packages/common/src/locales/ar/course-material.json
@@ -70,6 +70,7 @@
   "course-overview": "نظرة عامة على الدورة",
   "course-progress": "تقدم الدورة",
   "course-title": "دورة: {{title}}",
+  "current-page-unavailable-in-the-new-language-taking-you-to-the-front-page": "الصفحة الحالية غير متوفرة في النسخة اللغوية التي تقوم بالتبديل إليها. سيتم نقلك إلى الصفحة الرئيسية للدورة.",
   "custom-view-iframe-title": "محتوى متعلق بالتمارين",
   "deadline": "الموعد النهائي: ",
   "default-course-instance-name": "افتراضي",

--- a/shared-module/packages/common/src/locales/en/course-material.json
+++ b/shared-module/packages/common/src/locales/en/course-material.json
@@ -69,6 +69,7 @@
   "course-overview": "Course overview",
   "course-progress": "Course progress",
   "course-title": "Course: {{title}}",
+  "current-page-unavailable-in-the-new-language-taking-you-to-the-front-page": "The current page is not available in the language version you are switching to. You will be taken to the front page of the course.",
   "custom-view-iframe-title": "Content related to the exercises",
   "deadline": "Deadline: ",
   "default-course-instance-name": "Default",

--- a/shared-module/packages/common/src/locales/fi/course-material.json
+++ b/shared-module/packages/common/src/locales/fi/course-material.json
@@ -70,6 +70,7 @@
   "course-overview": "Kurssin yhteenveto",
   "course-progress": "Kurssin edistyminen",
   "course-title": "Kurssi: {{title}}",
+  "current-page-unavailable-in-the-new-language-taking-you-to-the-front-page": "Nykyinen sivu ei ole saatavilla kielellä, johon olet vaihtamassa. Sinut ohjataan kurssin etusivulle.",
   "custom-view-iframe-title": "Sisältö liittyen tehtäviin",
   "deadline": "Deadline: ",
   "default-course-instance-name": "Oletus",

--- a/shared-module/packages/common/src/locales/sv/course-material.json
+++ b/shared-module/packages/common/src/locales/sv/course-material.json
@@ -69,6 +69,7 @@
   "course-overview": "Kursöversikt",
   "course-progress": "Kursframsteg",
   "course-title": "Kurs: {{title}}",
+  "current-page-unavailable-in-the-new-language-taking-you-to-the-front-page": "Den aktuella sidan är inte tillgänglig på det språk du byter till. Du kommer att tas till kursens förstasida.",
   "custom-view-iframe-title": "Innehåll relaterat till övningarna",
   "deadline": "Deadline: ",
   "default-course-instance-name": "Standard",

--- a/shared-module/packages/common/src/locales/uk/course-material.json
+++ b/shared-module/packages/common/src/locales/uk/course-material.json
@@ -71,6 +71,7 @@
   "course-overview": "Огляд курсу",
   "course-progress": "Прогрес курсу",
   "course-title": "Курс: {{title}}",
+  "current-page-unavailable-in-the-new-language-taking-you-to-the-front-page": "Поточна сторінка недоступна мовою, на яку ви переключаєтеся. Вас буде перенаправлено на головну сторінку курсу.",
   "custom-view-iframe-title": "Контент, пов'язаний з вправами",
   "deadline": "Кінцевий термін:",
   "default-course-instance-name": "За замовчуванням",


### PR DESCRIPTION
* Updated `useLanguageNavigation` hook to include handling for unavailable pages in different languages, providing user feedback through alerts.
* Modified `CourseLanguageVersionNavigationInfo` to include a new field indicating if the current page is unavailable in the selected language.
* Improved localization by adding relevant messages for unavailable pages in multiple languages.
* Adjusted related components and bindings to accommodate the new field and ensure consistent behavior across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - When switching languages, the app now alerts you if the current page isn’t available in the target language and then redirects you to the course front page.
- Localization
  - Added translations for the new alert message in English, Finnish, Swedish, Arabic, and Ukrainian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->