### PR TITLE
Fix message in IpToCountryMapper

### DIFF
--- a/services/headless-lms/utils/src/ip_to_country.rs
+++ b/services/headless-lms/utils/src/ip_to_country.rs
@@ -34,7 +34,7 @@ impl IpToCountryMapper {
                 .max_open(10)
                 .contents_first(false)
                 .sort_by_file_name();
-            let mut some_lists_skipped = true;
+            let mut some_lists_skipped = false;
             for entry_result in walker {
                 let entry = entry_result?;
                 if !entry.file_type().is_file() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default warning behavior for skipped data lists to only appear when actually needed rather than by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->