### PR TITLE
Fix likert scale icons

### DIFF
--- a/services/course-material/src/components/ContentRenderer/moocfi/ExerciseBlock/PeerOrSelfReviewView/PeerOrSelfReviewsReceivedComponent/Likert.tsx
+++ b/services/course-material/src/components/ContentRenderer/moocfi/ExerciseBlock/PeerOrSelfReviewView/PeerOrSelfReviewsReceivedComponent/Likert.tsx
@@ -2,7 +2,13 @@ import styled from "@emotion/styled"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
-import { Agree, NeitherAgreeNorDisagree, StronglyDisagree } from "./LikertSvgs"
+import {
+  Agree,
+  Disagree,
+  NeitherAgreeNorDisagree,
+  StronglyAgree,
+  StronglyDisagree,
+} from "./LikertSvgs"
 
 import { headingFont } from "@/shared-module/common/styles"
 
@@ -71,7 +77,7 @@ const Likert: React.FC<LikertProps> = ({ question, content, index }) => {
     },
     {
       text: t("likert-scale-disagree"),
-      svg: Agree,
+      svg: Disagree,
     },
     {
       text: t("likert-scale-neither-agree-nor-disagree"),
@@ -83,7 +89,7 @@ const Likert: React.FC<LikertProps> = ({ question, content, index }) => {
     },
     {
       text: t("likert-scale-strongly-agree"),
-      svg: StronglyDisagree,
+      svg: StronglyAgree,
     },
   ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Likert rating scale component icons to correctly match their corresponding labels. Previously, the "disagree" and "strongly agree" options displayed incorrect visual icons. All rating scale options now display the appropriate visual representations that accurately correspond with their text labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->