### PR TITLE
Don't use pnpm when starting the slim images

### DIFF
--- a/services/cms/Dockerfile.production.slim.dockerfile
+++ b/services/cms/Dockerfile.production.slim.dockerfile
@@ -32,4 +32,7 @@ WORKDIR /app
 
 EXPOSE 3000
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3000
+
+CMD ["node", "server.js"]

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -11,7 +11,6 @@
     "postinstall": "pnpm run -F '**' postinstall:clean-wp && pnpm run -F '**' postinstall:remove-gutenberg-eslint-deps-that-breaks-our-eslint",
     "postinstall:clean-wp": "ts-node -O \"{\\\"module\\\":\\\"commonjs\\\"}\" scripts/cleanWordpressModules.ts",
     "postinstall:remove-gutenberg-eslint-deps-that-breaks-our-eslint": "find node_modules -maxdepth 1 -type d -name '*eslint*' -exec rm -r {} +",
-    "start": "NODE_ENV=production PORT=3000 node server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },
   "dependencies": {

--- a/services/course-material/Dockerfile.production.slim.dockerfile
+++ b/services/course-material/Dockerfile.production.slim.dockerfile
@@ -31,4 +31,7 @@ WORKDIR /app
 
 EXPOSE 3003
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3003
+
+CMD ["node", "server.js"]

--- a/services/course-material/package.json
+++ b/services/course-material/package.json
@@ -6,7 +6,6 @@
     "build": "NODE_ENV=production next build",
     "dev": "next dev --port 3003 --turbopack",
     "export": "next export",
-    "start": "NODE_ENV=production PORT=3003 node server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },
   "dependencies": {

--- a/services/example-exercise/Dockerfile.production.slim.dockerfile
+++ b/services/example-exercise/Dockerfile.production.slim.dockerfile
@@ -30,4 +30,7 @@ WORKDIR /app
 
 EXPOSE 3002
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3002
+
+CMD ["node", "server.js"]

--- a/services/example-exercise/package.json
+++ b/services/example-exercise/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "build": "NODE_ENV=production next build",
     "dev": "next dev --port 3002 --turbopack",
-    "export": "next export",
-    "start": "NODE_ENV=production PORT=3002 node server.js"
+    "export": "next export"
   },
   "dependencies": {
     "@emotion/css": "^11.13.5",

--- a/services/main-frontend/Dockerfile.production.slim.dockerfile
+++ b/services/main-frontend/Dockerfile.production.slim.dockerfile
@@ -34,4 +34,7 @@ WORKDIR /app
 
 EXPOSE 3000
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3000
+
+CMD ["node", "server.js"]

--- a/services/main-frontend/package.json
+++ b/services/main-frontend/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev --turbopack",
     "export": "next export",
     "postinstall": "mkdir -p public && cp -r ./node_modules/monaco-editor/min ./public/monaco-editor",
-    "start": "NODE_ENV=production PORT=3000 node server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },
   "dependencies": {

--- a/services/quizzes/Dockerfile.production.slim.dockerfile
+++ b/services/quizzes/Dockerfile.production.slim.dockerfile
@@ -30,4 +30,7 @@ WORKDIR /app
 
 EXPOSE 3004
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3004
+
+CMD ["node", "server.js"]

--- a/services/quizzes/package.json
+++ b/services/quizzes/package.json
@@ -6,7 +6,6 @@
     "build": "NODE_ENV=production next build",
     "dev": "next dev --port 3004 --turbopack",
     "export": "next export",
-    "start": "NODE_ENV=production PORT=3004 node server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest",
     "test-silent": "jest --silent"
   },

--- a/services/tmc/Dockerfile.production.slim.dockerfile
+++ b/services/tmc/Dockerfile.production.slim.dockerfile
@@ -35,4 +35,7 @@ WORKDIR /app
 
 EXPOSE 3005
 
-CMD [ "pnpm", "run", "start" ]
+ENV NODE_ENV=production
+ENV PORT=3005
+
+CMD ["node", "server.js"]

--- a/services/tmc/package.json
+++ b/services/tmc/package.json
@@ -6,7 +6,6 @@
     "build": "NODE_ENV=production next build",
     "dev": "next dev --port 3005 --turbopack",
     "export": "next export",
-    "start": "NODE_ENV=production PORT=3005 node server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },
   "dependencies": {


### PR DESCRIPTION
Using pnpm is unnecessary, and we don't want to accidentally start downloading new versions of pnpm or Node.js (which the project is otherwise configured to automatically do)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production deployment configuration across all services
  * Streamlined startup process by using direct Node.js execution in production containers
  * Consolidated environment variable configuration to Docker layer
  * Removed redundant startup scripts from package configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->