### PR TITLE
Add an api endpoint for TMC to post a new user and migrate password

### DIFF
--- a/services/headless-lms/server/src/controllers/tmc_server/users.rs
+++ b/services/headless-lms/server/src/controllers/tmc_server/users.rs
@@ -165,8 +165,12 @@ pub async fn create_user(
                     }
                     Err(e) => {
                         error!(
-                            "Background TMC notification exhausted all {} retries: upstream_id={}, user_id={}, error={}",
-                            MAX_ATTEMPTS_BG, upstream_id, user_id, e
+                            "Background TMC notification exhausted all {} retries at {}: upstream_id={}, user_id={}, error={}",
+                            MAX_ATTEMPTS_BG,
+                            chrono::Utc::now(),
+                            upstream_id,
+                            user_id,
+                            e
                         );
                     }
                 }


### PR DESCRIPTION
Add an api endpoint where TMC posts new users immediately after they're created in TMC.
The endpoint also moves password management for the user to courses's side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user creation endpoint that accepts a password, fetches or creates the user from the upstream service, stores the password securely within a transaction, and notifies the upstream system that password management is handled.
  * Endpoint returns the created/fetched user and a flag indicating whether the password was successfully set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->