### PR TITLE
Fix chatbot UTF-8 truncation bug

### DIFF
--- a/services/headless-lms/chatbot/src/azure_chatbot.rs
+++ b/services/headless-lms/chatbot/src/azure_chatbot.rs
@@ -35,6 +35,7 @@ use crate::llm_utils::{
     APIMessage, APIMessageKind, APIMessageText, APIMessageToolCall, APIMessageToolResponse,
     APITool, APIToolCall, estimate_tokens, make_streaming_llm_request,
 };
+use headless_lms_utils::strings::truncate_utf8_at_boundary;
 use headless_lms_utils::url_encoding::url_decode;
 
 use crate::prelude::*;
@@ -829,7 +830,7 @@ pub async fn parse_and_stream_to_user<'a>(
                     if let Some(context) = &delta.context {
                         let mut conn = pool.acquire().await?;
                         for (idx, cit) in context.citations.iter().enumerate() {
-                            let content = if cit.content.len() < 255 {cit.content.clone()} else {cit.content[0..255].to_string()};
+                            let content = truncate_utf8_at_boundary(&cit.content, 255).to_string();
                             let split = content.split_once(CONTENT_FIELD_SEPARATOR);
                             if split.is_none() {
                                 error!("Chatbot citation doesn't have any content or is missing 'chunk_context'. Something is wrong with Azure.");

--- a/services/headless-lms/utils/src/strings.rs
+++ b/services/headless-lms/utils/src/strings.rs
@@ -31,6 +31,18 @@ pub fn is_ietf_language_code_like(string: &str) -> bool {
     IETF_LANGUAGE_CODE_REGEX.is_match(string)
 }
 
+/// Truncates UTF-8 text to a max byte length at a valid char boundary.
+pub fn truncate_utf8_at_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut idx = max_bytes;
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    &s[..idx]
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -49,5 +61,30 @@ mod test {
         assert!(is_ietf_language_code_like("eng"));
         assert!(is_ietf_language_code_like("en-US"));
         assert!(is_ietf_language_code_like("in-Cans-CA"));
+    }
+
+    #[test]
+    fn truncate_utf8_at_boundary_returns_original_when_short() {
+        let input = "heillä";
+        let result = truncate_utf8_at_boundary(input, 255);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn truncate_utf8_at_boundary_handles_finnish_characters() {
+        let input = format!("{}äz", "a".repeat(254));
+        let result = truncate_utf8_at_boundary(&input, 255);
+        assert_eq!(result.as_bytes().len(), 254);
+        assert!(result.is_char_boundary(result.len()));
+        assert_eq!(result, "a".repeat(254));
+    }
+
+    #[test]
+    fn truncate_utf8_at_boundary_handles_emoji() {
+        let input = format!("{}😀z", "a".repeat(254));
+        let result = truncate_utf8_at_boundary(&input, 255);
+        assert_eq!(result.as_bytes().len(), 254);
+        assert!(result.is_char_boundary(result.len()));
+        assert_eq!(result, "a".repeat(254));
     }
 }


### PR DESCRIPTION
Turns out the implementation here could try to do the truncation in a position that is not a char boundary, resulting in invalid UTF-8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved citation content truncation to properly respect UTF-8 character boundaries, ensuring international characters and emoji are displayed correctly without corruption or data loss.

* **Tests**
  * Added comprehensive tests for UTF-8 safe text truncation, including coverage of international character sets, multibyte character sequences, and emoji handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->