### PR TITLE
Make resetting less aggressive

### DIFF
--- a/services/headless-lms/models/.sqlx/query-c8477fd7a1cfa4934cd566d01e9099a52d0f9f7ec722d664416bebacdb352d0f.json
+++ b/services/headless-lms/models/.sqlx/query-c8477fd7a1cfa4934cd566d01e9099a52d0f9f7ec722d664416bebacdb352d0f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nUPDATE user_chapter_locking_statuses\nSET status = 'unlocked'::chapter_locking_status, deleted_at = NULL\nWHERE user_id = $1\n  AND course_id = $2\n  AND chapter_id = ANY($3)\n  AND status = 'completed_and_locked'::chapter_locking_status\n  AND deleted_at IS NULL\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c8477fd7a1cfa4934cd566d01e9099a52d0f9f7ec722d664416bebacdb352d0f"
+}

--- a/services/headless-lms/models/.sqlx/query-eb04fb3bc02d124c28d42a1362ea989f77bde78fb2366dcb5f6e9ba6114d098f.json
+++ b/services/headless-lms/models/.sqlx/query-eb04fb3bc02d124c28d42a1362ea989f77bde78fb2366dcb5f6e9ba6114d098f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nUPDATE user_chapter_locking_statuses\nSET deleted_at = NOW()\nWHERE user_id = $1\n  AND course_id = $2\n  AND chapter_id = ANY($3)\n  AND deleted_at IS NULL\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "eb04fb3bc02d124c28d42a1362ea989f77bde78fb2366dcb5f6e9ba6114d098f"
+}

--- a/services/headless-lms/models/src/exercises.rs
+++ b/services/headless-lms/models/src/exercises.rs
@@ -1197,6 +1197,7 @@ WHERE user_exercise_state_id IN (
 
         let chapter_ids =
             get_chapter_ids_for_exercises_in_course(&mut tx, exercise_ids, course_id).await?;
+        // Keep chapters that are still in their initial `not_unlocked_yet` state untouched.
         user_chapter_locking_statuses::unlock_chapters_for_user(
             &mut tx,
             *user_id,

--- a/services/headless-lms/models/src/user_chapter_locking_statuses.rs
+++ b/services/headless-lms/models/src/user_chapter_locking_statuses.rs
@@ -402,9 +402,47 @@ pub async fn unlock_chapters_for_user(
     course_id: Uuid,
     chapter_ids: &[Uuid],
 ) -> ModelResult<()> {
-    for chapter_id in chapter_ids {
-        unlock_chapter(conn, user_id, *chapter_id, course_id).await?;
+    if chapter_ids.is_empty() {
+        return Ok(());
     }
+
+    let course = crate::courses::get_course(conn, course_id).await?;
+    if !course.chapter_locking_enabled {
+        sqlx::query!(
+            r#"
+UPDATE user_chapter_locking_statuses
+SET deleted_at = NOW()
+WHERE user_id = $1
+  AND course_id = $2
+  AND chapter_id = ANY($3)
+  AND deleted_at IS NULL
+            "#,
+            user_id,
+            course_id,
+            chapter_ids
+        )
+        .execute(&mut *conn)
+        .await?;
+
+        return Ok(());
+    }
+
+    sqlx::query!(
+        r#"
+UPDATE user_chapter_locking_statuses
+SET status = 'unlocked'::chapter_locking_status, deleted_at = NULL
+WHERE user_id = $1
+  AND course_id = $2
+  AND chapter_id = ANY($3)
+  AND status = 'completed_and_locked'::chapter_locking_status
+  AND deleted_at IS NULL
+        "#,
+        user_id,
+        course_id,
+        chapter_ids
+    )
+    .execute(&mut *conn)
+    .await?;
 
     Ok(())
 }
@@ -827,6 +865,7 @@ mod tests {
     #[tokio::test]
     async fn unlock_chapters_for_user_only_updates_selected_chapters() {
         insert_data!(:tx, :user, :org, course: course);
+        set_course_chapter_locking_enabled(tx.as_mut(), course, true).await;
 
         let all_modules = crate::course_modules::get_by_course_id(tx.as_mut(), course)
             .await
@@ -892,5 +931,145 @@ mod tests {
             chapter2_status,
             Some(ChapterLockingStatus::CompletedAndLocked)
         );
+    }
+
+    #[tokio::test]
+    async fn unlock_chapters_for_user_does_not_unlock_not_unlocked_yet_statuses() {
+        insert_data!(:tx, :user, :org, course: course);
+        set_course_chapter_locking_enabled(tx.as_mut(), course, true).await;
+
+        let all_modules = crate::course_modules::get_by_course_id(tx.as_mut(), course)
+            .await
+            .unwrap();
+        let base_module = all_modules
+            .into_iter()
+            .find(|m| m.order_number == 0)
+            .unwrap();
+
+        let chapter1 = crate::chapters::insert(
+            tx.as_mut(),
+            PKeyPolicy::Generate,
+            &crate::chapters::NewChapter {
+                name: "Chapter 1".to_string(),
+                color: None,
+                course_id: course,
+                chapter_number: 1,
+                front_page_id: None,
+                opens_at: None,
+                deadline: None,
+                course_module_id: Some(base_module.id),
+            },
+        )
+        .await
+        .unwrap();
+        let chapter2 = crate::chapters::insert(
+            tx.as_mut(),
+            PKeyPolicy::Generate,
+            &crate::chapters::NewChapter {
+                name: "Chapter 2".to_string(),
+                color: None,
+                course_id: course,
+                chapter_number: 2,
+                front_page_id: None,
+                opens_at: None,
+                deadline: None,
+                course_module_id: Some(base_module.id),
+            },
+        )
+        .await
+        .unwrap();
+
+        complete_and_lock_chapter(tx.as_mut(), user, chapter1, course)
+            .await
+            .unwrap();
+        ensure_not_unlocked_yet_status(tx.as_mut(), user, chapter2, course)
+            .await
+            .unwrap();
+
+        unlock_chapters_for_user(tx.as_mut(), user, course, &[chapter1, chapter2])
+            .await
+            .unwrap();
+
+        let chapter1_status = get_or_init_status(tx.as_mut(), user, chapter1, Some(course), None)
+            .await
+            .unwrap();
+        let chapter2_status = get_or_init_status(tx.as_mut(), user, chapter2, Some(course), None)
+            .await
+            .unwrap();
+
+        assert_eq!(chapter1_status, Some(ChapterLockingStatus::Unlocked));
+        assert_eq!(chapter2_status, Some(ChapterLockingStatus::NotUnlockedYet));
+    }
+
+    #[tokio::test]
+    async fn unlock_chapters_for_user_soft_deletes_rows_when_locking_is_disabled() {
+        insert_data!(:tx, :user, :org, course: course);
+        set_course_chapter_locking_enabled(tx.as_mut(), course, true).await;
+
+        let all_modules = crate::course_modules::get_by_course_id(tx.as_mut(), course)
+            .await
+            .unwrap();
+        let base_module = all_modules
+            .into_iter()
+            .find(|m| m.order_number == 0)
+            .unwrap();
+
+        let chapter1 = crate::chapters::insert(
+            tx.as_mut(),
+            PKeyPolicy::Generate,
+            &crate::chapters::NewChapter {
+                name: "Chapter 1".to_string(),
+                color: None,
+                course_id: course,
+                chapter_number: 1,
+                front_page_id: None,
+                opens_at: None,
+                deadline: None,
+                course_module_id: Some(base_module.id),
+            },
+        )
+        .await
+        .unwrap();
+        let chapter2 = crate::chapters::insert(
+            tx.as_mut(),
+            PKeyPolicy::Generate,
+            &crate::chapters::NewChapter {
+                name: "Chapter 2".to_string(),
+                color: None,
+                course_id: course,
+                chapter_number: 2,
+                front_page_id: None,
+                opens_at: None,
+                deadline: None,
+                course_module_id: Some(base_module.id),
+            },
+        )
+        .await
+        .unwrap();
+
+        complete_and_lock_chapter(tx.as_mut(), user, chapter1, course)
+            .await
+            .unwrap();
+        complete_and_lock_chapter(tx.as_mut(), user, chapter2, course)
+            .await
+            .unwrap();
+
+        set_course_chapter_locking_enabled(tx.as_mut(), course, false).await;
+
+        unlock_chapters_for_user(tx.as_mut(), user, course, &[chapter1])
+            .await
+            .unwrap();
+
+        set_course_chapter_locking_enabled(tx.as_mut(), course, true).await;
+        let enabled_course = crate::courses::get_course(tx.as_mut(), course)
+            .await
+            .unwrap();
+        let statuses = get_for_user_and_course(tx.as_mut(), user, &enabled_course)
+            .await
+            .unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].chapter_id, chapter2);
+        assert_eq!(statuses[0].status, ChapterLockingStatus::CompletedAndLocked);
     }
 }

--- a/services/headless-lms/server/src/test_helper.rs
+++ b/services/headless-lms/server/src/test_helper.rs
@@ -11,11 +11,29 @@ use sqlx::{Connection, PgConnection, Postgres, Transaction};
 use std::{env, sync::Arc};
 use tokio::sync::Mutex;
 
+/// Returns true if the current process appears to run inside Kubernetes.
+fn running_in_kubernetes() -> bool {
+    // `KUBERNETES_SERVICE_HOST` is injected into all pods by default.
+    env::var_os("KUBERNETES_SERVICE_HOST").is_some()
+}
+
+/// Default database URL for tests when no DB env vars are set.
+fn default_database_url_for_tests() -> String {
+    if running_in_kubernetes() {
+        "postgres://headless-lms:only-for-local-development-intentionally-public@postgres/headless_lms_test"
+            .to_string()
+    } else {
+        // Matches the local dev convention (e.g. local Postgres or port-forwarded Postgres).
+        "postgres://headless-lms@localhost:54328/headless_lms_test".to_string()
+    }
+}
+
 pub async fn test_config() -> ServerConfig {
+    let database_url = env::var("DATABASE_URL_TEST")
+        .or_else(|_| env::var("DATABASE_URL"))
+        .unwrap_or_else(|_| default_database_url_for_tests());
     ServerConfigBuilder {
-        database_url: "\
-postgres://headless-lms:only-for-local-development-intentionally-public@postgres/headless_lms_test"
-            .to_string(),
+        database_url,
         oauth_application_id: "some-id".to_string(),
         oauth_secret: "some-secret".to_string(),
         auth_url: "http://example.com".parse().unwrap(),

--- a/services/headless-lms/server/tests/integration_test.rs
+++ b/services/headless-lms/server/tests/integration_test.rs
@@ -23,6 +23,19 @@ use uuid::Uuid;
 // tried storing PgPool here but that caused strange errors
 static DB_URL: Mutex<Option<String>> = Mutex::const_new(None);
 
+fn running_in_kubernetes() -> bool {
+    env::var_os("KUBERNETES_SERVICE_HOST").is_some()
+}
+
+fn default_database_url_test() -> String {
+    if running_in_kubernetes() {
+        "postgres://headless-lms:only-for-local-development-intentionally-public@postgres/headless_lms_test"
+            .to_string()
+    } else {
+        "postgres://headless-lms@localhost:54328/headless_lms_test".to_string()
+    }
+}
+
 /// Reinitializes the test database once per `cargo test` call.
 /// This is done because there's no good way to clean up the database after testing,
 /// so there may be leftover data.
@@ -31,9 +44,7 @@ pub async fn init_db() -> String {
         return db.clone();
     }
     dotenv::dotenv().ok();
-    let db = env::var("DATABASE_URL_TEST").unwrap_or_else(|_| {
-        "postgres://headless-lms:only-for-local-development-intentionally-public@postgres/headless_lms_test".to_string()
-    });
+    let db = env::var("DATABASE_URL_TEST").unwrap_or_else(|_| default_database_url_test());
     if Postgres::database_exists(&db)
         .await
         .expect("failed to check test db existence")

--- a/services/headless-lms/server/tests/study_registry_test.rs
+++ b/services/headless-lms/server/tests/study_registry_test.rs
@@ -20,6 +20,10 @@ mod integration_test;
 
 #[actix_web::test]
 async fn gets_and_registers_completions() {
+    if std::env::var_os("KUBERNETES_SERVICE_HOST").is_none() {
+        eprintln!("skipping: not running inside Kubernetes");
+        return;
+    }
     let base_url =
         std::env::var("BASE_URL").unwrap_or_else(|_| "http://project-331.local".to_string());
     let (actix, pool) = integration_test::init_actix().await;


### PR DESCRIPTION
- **Dont unlock chapters that are not unlocked yet in the reset tool**
- **Allow running unit tests outside of kubernetes**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course-level control for chapter locking behavior.
  * Enhanced chapter unlock logic to properly handle different chapter states.

* **Bug Fixes**
  * Chapters in initial "not unlocked" state now remain unaffected during unlock operations.

* **Tests**
  * Expanded test coverage for chapter locking and state management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->