### PR TITLE
Fix non-ASCII characters in course-material URLs returning Not found

### DIFF
--- a/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.down.sql
+++ b/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.down.sql
@@ -1,0 +1,8 @@
+-- Intentionally a no-op.
+--
+-- The up migration is a one-way data normalization: it rewrites existing URL paths to the
+-- decoded-canonical form but does not record which rows it touched, so it cannot be reverted
+-- precisely. Reverting is also unnecessary — the application's page lookup tolerates both the
+-- decoded and the legacy fully-encoded representations, so rolling the schema back does not
+-- require restoring the encoded paths.
+SELECT 1;

--- a/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.up.sql
+++ b/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.up.sql
@@ -1,0 +1,80 @@
+-- Canonicalize stored URL paths to the decoded form used by `normalize_url_path_for_storage`.
+--
+-- Data created while the previous normalization was active (and any imported earlier) stored
+-- non-ASCII characters percent-encoded, e.g. "/chapter-1/%D1%8F%D0%BA". The application now
+-- stores and matches the decoded-canonical form ("/chapter-1/як"), where valid non-ASCII UTF-8
+-- is kept verbatim and only unsafe ASCII (space, '#', '%', ...) stays percent-encoded.
+--
+-- This rewrites existing `pages.url_path` and `url_redirections.old_url_path` to that form. The
+-- application's lookup already tolerates both representations, so this is a cleanup that makes
+-- the stored data consistent. Rows whose decoded value would collide with an existing row (per
+-- the relevant unique index) are left untouched. The statement is idempotent: re-running it is a
+-- no-op once paths are decoded.
+
+-- Decodes runs of percent-encoded NON-ASCII bytes (lead nibble 8-F, i.e. byte >= 0x80) back to
+-- raw UTF-8, while leaving literal characters and ASCII percent-escapes (%20, %23, %25, ...)
+-- intact. This mirrors `normalize_url_path_for_storage` for already-normalized inputs.
+CREATE FUNCTION decode_non_ascii_url_path(input text) RETURNS text
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+AS $$
+    SELECT string_agg(
+        CASE
+            WHEN token ~ '^(?:%[89A-Fa-f][0-9A-Fa-f])+$'
+                THEN convert_from(decode(replace(token, '%', ''), 'hex'), 'UTF8')
+            ELSE token
+        END,
+        ''
+        ORDER BY ord
+    )
+    FROM (
+        SELECT g[1] AS token, ord
+        FROM regexp_matches(input, '((?:%[89A-Fa-f][0-9A-Fa-f])+|.)', 'g')
+            WITH ORDINALITY AS r(g, ord)
+    ) AS tokens;
+$$;
+
+-- pages.url_path (unique index: (url_path, course_id) WHERE deleted_at IS NULL)
+WITH candidates AS (
+    SELECT id, course_id, url_path, decode_non_ascii_url_path(url_path) AS new_url_path
+    FROM pages
+    WHERE url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
+)
+UPDATE pages AS p
+SET url_path = c.new_url_path
+FROM candidates c
+WHERE p.id = c.id
+  AND c.new_url_path <> c.url_path
+  AND NOT EXISTS (
+      SELECT 1
+      FROM pages existing
+      WHERE existing.id <> p.id
+        AND existing.deleted_at IS NULL
+        AND existing.course_id = p.course_id
+        AND existing.url_path = c.new_url_path
+  );
+
+-- url_redirections.old_url_path
+-- (unique constraint: (course_id, old_url_path, deleted_at) NULLS NOT DISTINCT)
+WITH candidates AS (
+    SELECT id, course_id, deleted_at, old_url_path,
+           decode_non_ascii_url_path(old_url_path) AS new_old_url_path
+    FROM url_redirections
+    WHERE old_url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
+)
+UPDATE url_redirections AS r
+SET old_url_path = c.new_old_url_path
+FROM candidates c
+WHERE r.id = c.id
+  AND c.new_old_url_path <> c.old_url_path
+  AND NOT EXISTS (
+      SELECT 1
+      FROM url_redirections existing
+      WHERE existing.id <> r.id
+        AND existing.course_id = r.course_id
+        AND existing.deleted_at IS NOT DISTINCT FROM r.deleted_at
+        AND existing.old_url_path = c.new_old_url_path
+  );
+
+DROP FUNCTION decode_non_ascii_url_path(text);

--- a/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.up.sql
+++ b/services/headless-lms/migrations/20260624101042_normalize_page_url_paths_to_decoded_form.up.sql
@@ -7,9 +7,15 @@
 --
 -- This rewrites existing `pages.url_path` and `url_redirections.old_url_path` to that form. The
 -- application's lookup already tolerates both representations, so this is a cleanup that makes
--- the stored data consistent. Rows whose decoded value would collide with an existing row (per
--- the relevant unique index) are left untouched. The statement is idempotent: re-running it is a
--- no-op once paths are decoded.
+-- the stored data consistent. The statement is idempotent: re-running it is a no-op once paths
+-- are decoded.
+--
+-- If decoding would make two rows in the same course collide (e.g. both a decoded
+-- "/chapter-1/як" and an encoded "/chapter-1/%D1%8F%D0%BA" exist), the migration ABORTS with a
+-- message listing the offending rows. Silently skipping them would leave the encoded row
+-- orphaned: the application resolves the decoded form first, so the encoded duplicate would
+-- become permanently unreachable. Such collisions must be resolved manually (delete or merge
+-- the duplicate), after which the migration can be re-run.
 
 -- Decodes runs of percent-encoded NON-ASCII bytes (lead nibble 8-F, i.e. byte >= 0x80) back to
 -- raw UTF-8, while leaving literal characters and ASCII percent-escapes (%20, %23, %25, ...)
@@ -35,9 +41,69 @@ AS $$
     ) AS tokens;
 $$;
 
--- pages.url_path (unique index: (url_path, course_id) WHERE deleted_at IS NULL)
+-- Abort if decoding would collide within the pages unique index
+-- (url_path, exam_id, course_id, deleted_at) NULLS NOT DISTINCT. We group every page by its
+-- decoded target plus the rest of the index key: any group of more than one row is a collision,
+-- whether it is a decoded vs. encoded pair or two different encodings of the same path. GROUP BY
+-- treats equal values (including NULL = NULL) as the same group, matching NULLS NOT DISTINCT.
+DO $$
+DECLARE
+    collisions text;
+BEGIN
+    SELECT string_agg(line, E'\n' ORDER BY line)
+    INTO collisions
+    FROM (
+        SELECT format('  course %s exam %s deleted_at %s: %L (%s rows)', course_id, exam_id, deleted_at, target, count(*)) AS line
+        FROM (
+            SELECT course_id, exam_id, deleted_at,
+                   CASE
+                       WHEN url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
+                           THEN decode_non_ascii_url_path(url_path)
+                       ELSE url_path
+                   END AS target
+            FROM pages
+        ) mapped
+        GROUP BY course_id, exam_id, deleted_at, target
+        HAVING count(*) > 1
+    ) dups;
+
+    IF collisions IS NOT NULL THEN
+        RAISE EXCEPTION 'Cannot normalize page URL paths: decoding would make these (url_path, exam_id, course_id, deleted_at) targets collide. Resolve the duplicates manually, then re-run the migration:%', E'\n' || collisions;
+    END IF;
+END $$;
+
+-- Abort if decoding would collide within the url_redirections unique constraint
+-- (course_id, old_url_path, deleted_at) NULLS NOT DISTINCT. GROUP BY treats equal deleted_at
+-- (including NULL = NULL) as the same group, matching NULLS NOT DISTINCT.
+DO $$
+DECLARE
+    collisions text;
+BEGIN
+    SELECT string_agg(line, E'\n' ORDER BY line)
+    INTO collisions
+    FROM (
+        SELECT format('  course %s (deleted_at %s): %L (%s rows)', course_id, deleted_at, target, count(*)) AS line
+        FROM (
+            SELECT course_id, deleted_at,
+                   CASE
+                       WHEN old_url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
+                           THEN decode_non_ascii_url_path(old_url_path)
+                       ELSE old_url_path
+                   END AS target
+            FROM url_redirections
+        ) mapped
+        GROUP BY course_id, deleted_at, target
+        HAVING count(*) > 1
+    ) dups;
+
+    IF collisions IS NOT NULL THEN
+        RAISE EXCEPTION 'Cannot normalize redirection URL paths: decoding would make these (course, old_url_path, deleted_at) targets collide. Resolve the duplicates manually, then re-run the migration:%', E'\n' || collisions;
+    END IF;
+END $$;
+
+-- pages.url_path: collisions ruled out above, so the rewrite cannot violate the unique index.
 WITH candidates AS (
-    SELECT id, course_id, url_path, decode_non_ascii_url_path(url_path) AS new_url_path
+    SELECT id, url_path, decode_non_ascii_url_path(url_path) AS new_url_path
     FROM pages
     WHERE url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
 )
@@ -45,21 +111,11 @@ UPDATE pages AS p
 SET url_path = c.new_url_path
 FROM candidates c
 WHERE p.id = c.id
-  AND c.new_url_path <> c.url_path
-  AND NOT EXISTS (
-      SELECT 1
-      FROM pages existing
-      WHERE existing.id <> p.id
-        AND existing.deleted_at IS NULL
-        AND existing.course_id = p.course_id
-        AND existing.url_path = c.new_url_path
-  );
+  AND c.new_url_path <> c.url_path;
 
 -- url_redirections.old_url_path
--- (unique constraint: (course_id, old_url_path, deleted_at) NULLS NOT DISTINCT)
 WITH candidates AS (
-    SELECT id, course_id, deleted_at, old_url_path,
-           decode_non_ascii_url_path(old_url_path) AS new_old_url_path
+    SELECT id, old_url_path, decode_non_ascii_url_path(old_url_path) AS new_old_url_path
     FROM url_redirections
     WHERE old_url_path ~ '%[89A-Fa-f][0-9A-Fa-f]'
 )
@@ -67,14 +123,6 @@ UPDATE url_redirections AS r
 SET old_url_path = c.new_old_url_path
 FROM candidates c
 WHERE r.id = c.id
-  AND c.new_old_url_path <> c.old_url_path
-  AND NOT EXISTS (
-      SELECT 1
-      FROM url_redirections existing
-      WHERE existing.id <> r.id
-        AND existing.course_id = r.course_id
-        AND existing.deleted_at IS NOT DISTINCT FROM r.deleted_at
-        AND existing.old_url_path = c.new_old_url_path
-  );
+  AND c.new_old_url_path <> c.old_url_path;
 
 DROP FUNCTION decode_non_ascii_url_path(text);

--- a/services/headless-lms/models/src/pages.rs
+++ b/services/headless-lms/models/src/pages.rs
@@ -958,6 +958,23 @@ WHERE pages.course_id = $1
     Ok(page)
 }
 
+/// Looks up a non-deleted page in `course_id` whose stored `url_path` matches `url_path` in
+/// either the decoded-canonical or the legacy fully-encoded form (see
+/// [`url_path_lookup_candidates`]). Shared by the page lookup and its tests so both exercise
+/// the same candidate-matching logic.
+async fn find_page_by_requested_path(
+    conn: &mut PgConnection,
+    course_id: Uuid,
+    url_path: &str,
+) -> ModelResult<Option<Page>> {
+    for candidate in url_path_lookup_candidates(url_path) {
+        if let Some(page) = get_page_by_stored_path(conn, course_id, &candidate).await? {
+            return Ok(Some(page));
+        }
+    }
+    Ok(None)
+}
+
 pub async fn get_page_with_user_data_by_path(
     conn: &mut PgConnection,
     user_id: Option<Uuid>,
@@ -966,17 +983,7 @@ pub async fn get_page_with_user_data_by_path(
     file_store: &dyn FileStore,
     app_conf: &ApplicationConfiguration,
 ) -> ModelResult<CoursePageWithUserData> {
-    let candidates = url_path_lookup_candidates(url_path);
-
-    let mut page_option = None;
-    for candidate in &candidates {
-        page_option = get_page_by_stored_path(conn, course_data.id, candidate).await?;
-        if page_option.is_some() {
-            break;
-        }
-    }
-
-    if let Some(page) = page_option {
+    if let Some(page) = find_page_by_requested_path(conn, course_data.id, url_path).await? {
         return get_course_page_with_user_data_from_selected_page(
             conn,
             user_id,
@@ -987,27 +994,21 @@ pub async fn get_page_with_user_data_by_path(
             app_conf,
         )
         .await;
-    } else {
-        let mut potential_redirect = None;
-        for candidate in &candidates {
-            potential_redirect =
-                try_to_find_redirected_page_by_stored_path(conn, course_data.id, candidate).await?;
-            if potential_redirect.is_some() {
-                break;
-            }
-        }
-        if let Some(redirected_page) = potential_redirect {
-            return get_course_page_with_user_data_from_selected_page(
-                conn,
-                user_id,
-                redirected_page,
-                true,
-                course_data.is_test_mode,
-                file_store,
-                app_conf,
-            )
-            .await;
-        }
+    }
+
+    if let Some(redirected_page) =
+        try_to_find_redirected_page(conn, course_data.id, url_path).await?
+    {
+        return get_course_page_with_user_data_from_selected_page(
+            conn,
+            user_id,
+            redirected_page,
+            true,
+            course_data.is_test_mode,
+            file_store,
+            app_conf,
+        )
+        .await;
     }
 
     Err(model_err!(NotFound, "Page not found".to_string()))
@@ -4203,28 +4204,27 @@ mod test {
         .unwrap();
         {
             let conn: &mut sqlx::PgConnection = tx.as_mut();
-            sqlx::query("UPDATE pages SET url_path = $1 WHERE id = $2")
-                .bind("/chapter-1/%D1%96%D1%81%D0%BF%D0%B8%D1%82")
-                .bind(legacy_page.id)
-                .execute(conn)
-                .await
-                .unwrap();
+            sqlx::query!(
+                "UPDATE pages SET url_path = $2 WHERE pages.id = $1",
+                legacy_page.id,
+                "/chapter-1/%D1%96%D1%81%D0%BF%D0%B8%D1%82"
+            )
+            .execute(conn)
+            .await
+            .unwrap();
         }
 
+        // Looks the page up through the same helper the production lookup uses, so a
+        // regression in the candidate matching is caught here.
         async fn lookup(
             conn: &mut sqlx::PgConnection,
             course_id: uuid::Uuid,
             requested: &str,
         ) -> Option<uuid::Uuid> {
-            for candidate in super::url_path_lookup_candidates(requested) {
-                if let Some(page) = super::get_page_by_stored_path(conn, course_id, &candidate)
-                    .await
-                    .unwrap()
-                {
-                    return Some(page.id);
-                }
-            }
-            None
+            super::find_page_by_requested_path(conn, course_id, requested)
+                .await
+                .unwrap()
+                .map(|page| page.id)
         }
 
         // The raw-Cyrillic page resolves whether the request arrives decoded or encoded.

--- a/services/headless-lms/models/src/pages.rs
+++ b/services/headless-lms/models/src/pages.rs
@@ -150,10 +150,55 @@ const URL_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'|')
     .add(b'}');
 
-/// Percent-encodes URL path characters that are not part of the safe path alphabet.
+/// Canonicalizes a URL path for storage and lookup.
+///
+/// Percent-decodes any escapes, trims surrounding whitespace, then re-encodes only the
+/// unsafe ASCII characters in `URL_PATH_ENCODE_SET`. Valid non-ASCII UTF-8 (e.g. Cyrillic)
+/// is kept verbatim so that paths stay human-readable and continue to match values that
+/// were stored before URL normalization was introduced.
+///
+/// `utf8_percent_encode` always percent-encodes non-ASCII bytes regardless of the set, so
+/// only ASCII characters are run through it; everything else is passed through unchanged.
 fn normalize_url_path_for_storage(url_path: &str) -> String {
     let decoded = percent_decode_str(url_path).decode_utf8_lossy();
+    let trimmed = decoded.trim();
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut buf = [0u8; 4];
+    for ch in trimmed.chars() {
+        if ch.is_ascii() {
+            // For an ASCII char, utf8_percent_encode encodes it iff it is in the set.
+            normalized.extend(utf8_percent_encode(
+                ch.encode_utf8(&mut buf),
+                URL_PATH_ENCODE_SET,
+            ));
+        } else {
+            normalized.push(ch);
+        }
+    }
+    normalized
+}
+
+/// The fully percent-encoded form that the previous normalization stored for paths
+/// containing non-ASCII characters (it also percent-encoded those characters). Used only
+/// as an additional lookup candidate so that pages stored before the decoded-canonical
+/// form was adopted still resolve.
+fn legacy_fully_encoded_url_path(url_path: &str) -> String {
+    let decoded = percent_decode_str(url_path).decode_utf8_lossy();
     utf8_percent_encode(decoded.trim(), URL_PATH_ENCODE_SET).to_string()
+}
+
+/// The stored `url_path` forms to try when looking up a page by a requested path: the
+/// decoded-canonical form (current storage form) and the legacy fully-encoded form. The
+/// legacy form is included only when it differs, which happens only for paths containing
+/// non-ASCII characters.
+fn url_path_lookup_candidates(url_path: &str) -> Vec<String> {
+    let normalized = normalize_url_path_for_storage(url_path);
+    let legacy = legacy_fully_encoded_url_path(url_path);
+    if legacy == normalized {
+        vec![normalized]
+    } else {
+        vec![normalized, legacy]
+    }
 }
 
 async fn get_lock_chapter_content_state_for_page(
@@ -921,8 +966,15 @@ pub async fn get_page_with_user_data_by_path(
     file_store: &dyn FileStore,
     app_conf: &ApplicationConfiguration,
 ) -> ModelResult<CoursePageWithUserData> {
-    let normalized_url_path = normalize_url_path_for_storage(url_path);
-    let page_option = get_page_by_stored_path(conn, course_data.id, &normalized_url_path).await?;
+    let candidates = url_path_lookup_candidates(url_path);
+
+    let mut page_option = None;
+    for candidate in &candidates {
+        page_option = get_page_by_stored_path(conn, course_data.id, candidate).await?;
+        if page_option.is_some() {
+            break;
+        }
+    }
 
     if let Some(page) = page_option {
         return get_course_page_with_user_data_from_selected_page(
@@ -936,9 +988,14 @@ pub async fn get_page_with_user_data_by_path(
         )
         .await;
     } else {
-        let potential_redirect =
-            try_to_find_redirected_page_by_stored_path(conn, course_data.id, &normalized_url_path)
-                .await?;
+        let mut potential_redirect = None;
+        for candidate in &candidates {
+            potential_redirect =
+                try_to_find_redirected_page_by_stored_path(conn, course_data.id, candidate).await?;
+            if potential_redirect.is_some() {
+                break;
+            }
+        }
         if let Some(redirected_page) = potential_redirect {
             return get_course_page_with_user_data_from_selected_page(
                 conn,
@@ -961,8 +1018,14 @@ pub async fn try_to_find_redirected_page(
     course_id: Uuid,
     url_path: &str,
 ) -> ModelResult<Option<Page>> {
-    let normalized_url_path = normalize_url_path_for_storage(url_path);
-    try_to_find_redirected_page_by_stored_path(conn, course_id, &normalized_url_path).await
+    for candidate in url_path_lookup_candidates(url_path) {
+        if let Some(page) =
+            try_to_find_redirected_page_by_stored_path(conn, course_id, &candidate).await?
+        {
+            return Ok(Some(page));
+        }
+    }
+    Ok(None)
 }
 
 async fn try_to_find_redirected_page_by_stored_path(
@@ -4047,6 +4110,147 @@ mod test {
         assert_eq!(
             normalize_url_path_for_storage(" /literal%25percent "),
             "/literal%25percent"
+        );
+    }
+
+    #[test]
+    fn keeps_non_ascii_characters_decoded_for_storage() {
+        // Valid non-ASCII (Cyrillic) is kept verbatim, regardless of whether the input
+        // arrives decoded or percent-encoded.
+        assert_eq!(
+            normalize_url_path_for_storage("/chapter-1/як"),
+            "/chapter-1/як"
+        );
+        assert_eq!(
+            normalize_url_path_for_storage("/chapter-1/%D1%8F%D0%BA"),
+            "/chapter-1/як"
+        );
+        // Unsafe ASCII is still encoded even when mixed with non-ASCII.
+        assert_eq!(
+            normalize_url_path_for_storage("/chapter 1/як"),
+            "/chapter%201/як"
+        );
+    }
+
+    #[test]
+    fn legacy_fully_encoded_form_encodes_non_ascii() {
+        assert_eq!(
+            legacy_fully_encoded_url_path("/chapter-1/як"),
+            "/chapter-1/%D1%8F%D0%BA"
+        );
+        assert_eq!(
+            legacy_fully_encoded_url_path("/chapter-1/%D1%8F%D0%BA"),
+            "/chapter-1/%D1%8F%D0%BA"
+        );
+    }
+
+    #[test]
+    fn lookup_candidates_cover_both_stored_forms() {
+        // ASCII-only paths have a single candidate (both forms are identical).
+        assert_eq!(
+            url_path_lookup_candidates("/chapter-1/foo"),
+            vec!["/chapter-1/foo".to_string()]
+        );
+        // Non-ASCII paths are looked up in both the decoded-canonical and legacy forms.
+        assert_eq!(
+            url_path_lookup_candidates("/chapter-1/як"),
+            vec![
+                "/chapter-1/як".to_string(),
+                "/chapter-1/%D1%8F%D0%BA".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn finds_pages_with_non_ascii_paths_in_either_stored_form() {
+        insert_data!(:tx, :user, :org, :course, instance: _instance, :course_module, :chapter);
+
+        let new_page = |url_path: &str, title: &str| NewPage {
+            exercises: vec![],
+            exercise_slides: vec![],
+            exercise_tasks: vec![],
+            content: vec![],
+            url_path: url_path.to_string(),
+            title: title.to_string(),
+            course_id: Some(course),
+            exam_id: None,
+            chapter_id: Some(chapter),
+            front_page_of_chapter_id: None,
+            content_search_language: None,
+        };
+
+        // Stored in the decoded-canonical form (raw Cyrillic), as insert_page now stores it.
+        let raw_page = crate::pages::insert_page(
+            tx.as_mut(),
+            new_page("/chapter-1/як", "Raw"),
+            user,
+            |_, _, _| unimplemented!(),
+            |_| unimplemented!(),
+        )
+        .await
+        .unwrap();
+
+        // Stored in the legacy fully-encoded form, simulating data written before the
+        // decoded-canonical form was adopted (insert_page normalizes, so update directly).
+        let legacy_page = crate::pages::insert_page(
+            tx.as_mut(),
+            new_page("/chapter-1/іспит", "Legacy"),
+            user,
+            |_, _, _| unimplemented!(),
+            |_| unimplemented!(),
+        )
+        .await
+        .unwrap();
+        {
+            let conn: &mut sqlx::PgConnection = tx.as_mut();
+            sqlx::query("UPDATE pages SET url_path = $1 WHERE id = $2")
+                .bind("/chapter-1/%D1%96%D1%81%D0%BF%D0%B8%D1%82")
+                .bind(legacy_page.id)
+                .execute(conn)
+                .await
+                .unwrap();
+        }
+
+        async fn lookup(
+            conn: &mut sqlx::PgConnection,
+            course_id: uuid::Uuid,
+            requested: &str,
+        ) -> Option<uuid::Uuid> {
+            for candidate in super::url_path_lookup_candidates(requested) {
+                if let Some(page) = super::get_page_by_stored_path(conn, course_id, &candidate)
+                    .await
+                    .unwrap()
+                {
+                    return Some(page.id);
+                }
+            }
+            None
+        }
+
+        // The raw-Cyrillic page resolves whether the request arrives decoded or encoded.
+        assert_eq!(
+            lookup(tx.as_mut(), course, "/chapter-1/як").await,
+            Some(raw_page.id)
+        );
+        assert_eq!(
+            lookup(tx.as_mut(), course, "/chapter-1/%D1%8F%D0%BA").await,
+            Some(raw_page.id)
+        );
+
+        // The legacy fully-encoded page resolves via the legacy lookup candidate, whether
+        // the request arrives decoded or encoded.
+        assert_eq!(
+            lookup(tx.as_mut(), course, "/chapter-1/іспит").await,
+            Some(legacy_page.id)
+        );
+        assert_eq!(
+            lookup(
+                tx.as_mut(),
+                course,
+                "/chapter-1/%D1%96%D1%81%D0%BF%D0%B8%D1%82"
+            )
+            .await,
+            Some(legacy_page.id)
         );
     }
 

--- a/services/main-frontend/src/app/org/[organizationSlug]/(course-material)/courses/[courseSlug]/[...path]/page.tsx
+++ b/services/main-frontend/src/app/org/[organizationSlug]/(course-material)/courses/[courseSlug]/[...path]/page.tsx
@@ -34,7 +34,20 @@ const PagePage: React.FC = () => {
   }
   const organizationSlug = params.organizationSlug
   const courseSlug = params.courseSlug
-  const path = useMemo(() => `/${params.path?.join("/") || ""}`, [params.path])
+  // useParams() returns the catch-all segments still percent-encoded, so decode each
+  // segment (per-segment, so encoded separators are not misread) before building the path.
+  const path = useMemo(() => {
+    const decoded = (params.path ?? [])
+      .map((segment) => {
+        try {
+          return decodeURIComponent(segment)
+        } catch {
+          return segment
+        }
+      })
+      .join("/")
+    return `/${decoded}`
+  }, [params.path])
 
   // Stable object reference for view params
   const viewParams = useMemo(

--- a/services/main-frontend/src/app/org/[organizationSlug]/(course-material)/courses/[courseSlug]/[...path]/page.tsx
+++ b/services/main-frontend/src/app/org/[organizationSlug]/(course-material)/courses/[courseSlug]/[...path]/page.tsx
@@ -25,6 +25,23 @@ import { courseLanguagePreferenceAtom } from "@/state/courseLanguagePreference"
 import { organizationSlugAtom } from "@/state/layoutAtoms"
 import { useChangeCourseMaterialLanguage } from "@/utils/course-material/languageHelpers"
 
+/**
+ * Decodes only the non-ASCII (UTF-8 multibyte) percent-escapes in a path segment, leaving
+ * reserved ASCII escapes (%2F, %23, %25, ...) encoded. This mirrors the backend's canonical
+ * URL path form (`normalize_url_path_for_storage`), so decoding never turns an encoded
+ * separator into a structural one and changes the lookup key.
+ */
+const decodeNonAsciiPercentEscapes = (segment: string): string =>
+  // A run of %XX escapes whose lead nibble is 8-F encodes bytes >= 0x80, i.e. a non-ASCII
+  // UTF-8 sequence; decode the whole run at once so multibyte characters round-trip.
+  segment.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (run) => {
+    try {
+      return decodeURIComponent(run)
+    } catch {
+      return run
+    }
+  })
+
 const PagePage: React.FC = () => {
   const router = useRouter()
   const languageOptions = useLanguageOptions()
@@ -34,18 +51,11 @@ const PagePage: React.FC = () => {
   }
   const organizationSlug = params.organizationSlug
   const courseSlug = params.courseSlug
-  // useParams() returns the catch-all segments still percent-encoded, so decode each
-  // segment (per-segment, so encoded separators are not misread) before building the path.
+  // useParams() returns the catch-all segments still percent-encoded. Decode only the
+  // non-ASCII escapes per segment so the path matches the backend's canonical form while
+  // reserved ASCII escapes (e.g. %2F) stay encoded and structure is preserved.
   const path = useMemo(() => {
-    const decoded = (params.path ?? [])
-      .map((segment) => {
-        try {
-          return decodeURIComponent(segment)
-        } catch {
-          return segment
-        }
-      })
-      .join("/")
+    const decoded = (params.path ?? []).map(decodeNonAsciiPercentEscapes).join("/")
     return `/${decoded}`
   }, [params.path])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page and redirect resolution so URLs work correctly whether path segments arrive decoded or percent-encoded.
  * Fixed course material routing to properly decode non-ASCII percent-escapes while keeping reserved separators intact, improving link reliability.
  * Normalized stored page URL paths to a consistent decoded form, while maintaining compatibility with older, fully-encoded entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->