### PR TITLE
Dont crash if chatbot search finds no results

### DIFF
--- a/services/headless-lms/models/src/chatbot_conversation_messages_citations.rs
+++ b/services/headless-lms/models/src/chatbot_conversation_messages_citations.rs
@@ -71,6 +71,9 @@ pub async fn insert_batch(
     input: Vec<ChatbotConversationMessageCitation>,
     page_ids: Vec<Option<Uuid>>,
 ) -> ModelResult<Vec<ChatbotConversationMessageCitation>> {
+    if input.is_empty() {
+        return Ok(vec![]);
+    }
     let conv_id = input[0].conversation_id;
     let cm_ids: Vec<Uuid> = input.iter().map(|x| x.conversation_message_id).collect();
     let titles: Vec<String> = input.iter().map(|x| x.title.to_owned()).collect();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where saving conversation message citations could fail when no items were provided.
  * Empty batches now return successfully without trying to read from missing input, improving stability for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->