### PR TITLE
Prevent duplicate users from concurrent TMC create-user requests

### DIFF
--- a/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.down.sql
+++ b/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX users_upstream_id_active_uniq_idx;
+DROP INDEX IF EXISTS users_upstream_id_active_uniq_idx;

--- a/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.down.sql
+++ b/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX users_upstream_id_active_uniq_idx;

--- a/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.up.sql
+++ b/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.up.sql
@@ -1,11 +1,18 @@
 -- Prevent concurrent user creations (e.g. parallel TMC-server create-user requests during
 -- password migration) from inserting duplicate users for the same TMC account. Partial so that
 -- soft-deleted users don't block re-creating an account with the same upstream_id.
--- If this migration fails, duplicate active users with the same upstream_id already exist and
--- must be merged manually first:
+--
+-- In production, create this index with CONCURRENTLY before applying this migration (a plain
+-- CREATE INDEX blocks writes to users while it builds; CONCURRENTLY cannot run inside the
+-- migration transaction):
+--   CREATE UNIQUE INDEX CONCURRENTLY users_upstream_id_active_uniq_idx ON users (upstream_id)
+--   WHERE upstream_id IS NOT NULL AND deleted_at IS NULL;
+--
+-- If this fails, duplicate active users with the same upstream_id already exist and must be
+-- merged manually first:
 --   SELECT upstream_id, array_agg(id) FROM users
 --   WHERE upstream_id IS NOT NULL AND deleted_at IS NULL
 --   GROUP BY upstream_id HAVING count(*) > 1;
-CREATE UNIQUE INDEX users_upstream_id_active_uniq_idx ON users (upstream_id)
+CREATE UNIQUE INDEX IF NOT EXISTS users_upstream_id_active_uniq_idx ON users (upstream_id)
 WHERE upstream_id IS NOT NULL
   AND deleted_at IS NULL;

--- a/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.up.sql
+++ b/services/headless-lms/migrations/20260703090000_add-unique-index-users-upstream-id.up.sql
@@ -1,0 +1,11 @@
+-- Prevent concurrent user creations (e.g. parallel TMC-server create-user requests during
+-- password migration) from inserting duplicate users for the same TMC account. Partial so that
+-- soft-deleted users don't block re-creating an account with the same upstream_id.
+-- If this migration fails, duplicate active users with the same upstream_id already exist and
+-- must be merged manually first:
+--   SELECT upstream_id, array_agg(id) FROM users
+--   WHERE upstream_id IS NOT NULL AND deleted_at IS NULL
+--   GROUP BY upstream_id HAVING count(*) > 1;
+CREATE UNIQUE INDEX users_upstream_id_active_uniq_idx ON users (upstream_id)
+WHERE upstream_id IS NOT NULL
+  AND deleted_at IS NULL;

--- a/services/headless-lms/models/src/error.rs
+++ b/services/headless-lms/models/src/error.rs
@@ -257,6 +257,14 @@ impl From<sqlx::Error> for ModelError {
                             err.to_string(),
                             Some(err.into()),
                         ),
+                        "users_upstream_id_active_uniq_idx" => ModelError::new(
+                            ModelErrorType::DatabaseConstraint {
+                                constraint: constraint.to_string(),
+                                description: "A user with this upstream id already exists.",
+                            },
+                            err.to_string(),
+                            Some(err.into()),
+                        ),
                         "unique_chatbot_names_within_course" => ModelError::new(
                             ModelErrorType::DatabaseConstraint {
                                 constraint: constraint.to_string(),

--- a/services/headless-lms/server/src/domain/authorization.rs
+++ b/services/headless-lms/server/src/domain/authorization.rs
@@ -942,7 +942,7 @@ pub async fn get_or_create_user_from_tmc_mooc_fi_response(
     let user = match models::users::find_by_upstream_id(conn, upstream_id).await? {
         Some(existing_user) => existing_user,
         None => {
-            models::users::insert_with_upstream_id_and_moocfi_id(
+            let inserted = models::users::insert_with_upstream_id_and_moocfi_id(
                 conn,
                 &email,
                 // convert empty names to None
@@ -959,7 +959,18 @@ pub async fn get_or_create_user_from_tmc_mooc_fi_response(
                 upstream_id,
                 id,
             )
-            .await?
+            .await;
+            match inserted {
+                Ok(user) => user,
+                Err(insert_error) => {
+                    // A concurrent request can create the user between the find and the insert
+                    // (the insert runs in a savepoint, so the connection stays usable). The unique
+                    // index on upstream_id rejects the loser; return the winner's row instead.
+                    models::users::find_by_upstream_id(conn, upstream_id)
+                        .await?
+                        .ok_or(insert_error)?
+                }
+            }
         }
     };
     Ok(user)

--- a/services/headless-lms/server/src/domain/authorization.rs
+++ b/services/headless-lms/server/src/domain/authorization.rs
@@ -960,14 +960,21 @@ pub async fn get_or_create_user_from_tmc_mooc_fi_response(
             .await;
             match inserted {
                 Ok(user) => user,
-                Err(insert_error) => {
-                    // A concurrent request can create the user between the find and the insert
-                    // (the insert runs in a savepoint, so the connection stays usable). The unique
-                    // index on upstream_id rejects the loser; return the winner's row instead.
+                // A concurrent request can create the user between the find and the insert
+                // (the insert runs in a savepoint, so the connection stays usable). The unique
+                // index on upstream_id rejects the loser; return the winner's row instead.
+                Err(insert_error)
+                    if matches!(
+                        insert_error.error_type(),
+                        models::ModelErrorType::DatabaseConstraint { constraint, .. }
+                            if constraint == "users_upstream_id_active_uniq_idx"
+                    ) =>
+                {
                     models::users::find_by_upstream_id(conn, upstream_id)
                         .await?
                         .ok_or(insert_error)?
                 }
+                Err(insert_error) => return Err(insert_error.into()),
             }
         }
     };

--- a/services/headless-lms/server/src/domain/authorization.rs
+++ b/services/headless-lms/server/src/domain/authorization.rs
@@ -945,17 +945,15 @@ pub async fn get_or_create_user_from_tmc_mooc_fi_response(
             let inserted = models::users::insert_with_upstream_id_and_moocfi_id(
                 conn,
                 &email,
-                // convert empty names to None
-                if user_field.first_name.trim().is_empty() {
-                    None
-                } else {
-                    Some(user_field.first_name.as_str())
-                },
-                if user_field.last_name.trim().is_empty() {
-                    None
-                } else {
-                    Some(user_field.last_name.as_str())
-                },
+                // convert missing/empty names to None
+                user_field
+                    .first_name
+                    .as_deref()
+                    .filter(|s| !s.trim().is_empty()),
+                user_field
+                    .last_name
+                    .as_deref()
+                    .filter(|s| !s.trim().is_empty()),
                 upstream_id,
                 id,
             )

--- a/services/headless-lms/utils/src/services/tmc.rs
+++ b/services/headless-lms/utils/src/services/tmc.rs
@@ -51,14 +51,22 @@ pub struct TMCUser {
     pub email: String,
     pub administrator: bool,
     pub courses_mooc_fi_user_id: Option<Uuid>,
+    #[serde(default)]
     pub user_field: TMCUserField,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// User fields are optional data on the TMC side: a user who never filled in their profile (or a
+/// TMC instance without the field definitions) serializes them as null or omits them entirely, so
+/// deserialization must not require them.
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct TMCUserField {
-    pub first_name: String,
-    pub last_name: String,
-    pub organizational_id: String,
+    #[serde(default)]
+    pub first_name: Option<String>,
+    #[serde(default)]
+    pub last_name: Option<String>,
+    #[serde(default)]
+    pub organizational_id: Option<String>,
+    #[serde(default)]
     pub course_announcements: bool,
 }
 


### PR DESCRIPTION
find-then-insert in get_or_create_user_from_tmc_mooc_fi_response races when two requests arrive for the same not-yet-created upstream_id (which the tmc-server login-migration PR makes likely — parallel basic-auth API requests); adds a partial unique index on active users.upstream_id and makes the loser of the race fetch and return the winner's row. Include the pre-merge caution prominently: if production already has duplicate active users with the same upstream_id, the migration fails and blocks deploy — the check query is in the migration file's comment.

see https://github.com/testmycode/tmc-server/pull/595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate active user records for the same external upstream identifier.
  * Improves reliability of the user creation flow under concurrent requests by correctly resolving uniqueness conflicts.
  * Enables recreating users that were previously soft-deleted without running into active-user collisions.
* **Other**
  * Makes external TMC user field parsing more tolerant of missing/empty optional data (e.g., first/last name and organization ID).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->