### PR TITLE
Block clicks on QueryResult content until the refresh blur has fully animated out

### DIFF
--- a/shared-module/packages/components/__tests__/QueryResult.test.tsx
+++ b/shared-module/packages/components/__tests__/QueryResult.test.tsx
@@ -2,7 +2,7 @@
 
 import { css } from "@emotion/css"
 import type { UseQueryResult } from "@tanstack/react-query"
-import { act, screen } from "@testing-library/react"
+import { act, fireEvent, screen } from "@testing-library/react"
 
 import { QueryResult } from "../src/components/queryResult/QueryResult"
 
@@ -175,6 +175,66 @@ test("treatNullAsEmpty shows empty fallback for null data", () => {
   )
 
   expect(screen.getByText("null-empty")).toBeInTheDocument()
+})
+
+/** jsdom has no TransitionEvent constructor, so build the event by hand. */
+function fireTransitionEnd(element: Element, propertyName: string) {
+  const event = new Event("transitionend", { bubbles: true })
+  Object.assign(event, { propertyName })
+  fireEvent(element, event)
+}
+
+test("refreshing marker stays attached until the blur-out transition genuinely ends", () => {
+  const { rerender } = renderUi(
+    <QueryResult query={makeQuery({ data: "ok", isFetching: true })} themeMode="light">
+      {(d: string) => <div>{d}</div>}
+    </QueryResult>,
+  )
+
+  expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
+
+  // The query settled, but the blur-out transition is still running: stay marked busy.
+  rerender(
+    <QueryResult query={makeQuery({ data: "ok", isFetching: false })} themeMode="light">
+      {(d: string) => <div>{d}</div>}
+    </QueryResult>,
+  )
+  const content = screen.getByText("ok").parentElement as HTMLElement
+  expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
+
+  // Unrelated transition properties and transitions bubbling from children must not unblock.
+  fireTransitionEnd(content, "opacity")
+  expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
+  fireTransitionEnd(screen.getByText("ok"), "filter")
+  expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
+
+  fireTransitionEnd(content, "filter")
+  expect(screen.queryByTestId("query-refreshing")).not.toBeInTheDocument()
+})
+
+test("refreshing marker clears via fallback timer when no transitionend arrives", () => {
+  jest.useFakeTimers()
+  try {
+    const { rerender } = renderUi(
+      <QueryResult query={makeQuery({ data: "ok", isFetching: true })} themeMode="light">
+        {(d: string) => <div>{d}</div>}
+      </QueryResult>,
+    )
+
+    rerender(
+      <QueryResult query={makeQuery({ data: "ok", isFetching: false })} themeMode="light">
+        {(d: string) => <div>{d}</div>}
+      </QueryResult>,
+    )
+    expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(600)
+    })
+    expect(screen.queryByTestId("query-refreshing")).not.toBeInTheDocument()
+  } finally {
+    jest.useRealTimers()
+  }
 })
 
 test("refreshing announces status", () => {

--- a/shared-module/packages/components/__tests__/QueryResult.test.tsx
+++ b/shared-module/packages/components/__tests__/QueryResult.test.tsx
@@ -193,7 +193,7 @@ test("refreshing marker stays attached until the blur-out transition genuinely e
 
   expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
 
-  // The query settled, but the blur-out transition is still running: stay marked busy.
+  // Query settled but blur-out still running: stay marked busy.
   rerender(
     <QueryResult query={makeQuery({ data: "ok", isFetching: false })} themeMode="light">
       {(d: string) => <div>{d}</div>}
@@ -202,7 +202,7 @@ test("refreshing marker stays attached until the blur-out transition genuinely e
   const content = screen.getByText("ok").parentElement as HTMLElement
   expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
 
-  // Unrelated transition properties and transitions bubbling from children must not unblock.
+  // Wrong property or bubbled from a child: must not unblock.
   fireTransitionEnd(content, "opacity")
   expect(screen.getByTestId("query-refreshing")).toBeInTheDocument()
   fireTransitionEnd(screen.getByText("ok"), "filter")

--- a/shared-module/packages/components/src/components/queryResult/AnimatedQueryFrame.tsx
+++ b/shared-module/packages/components/src/components/queryResult/AnimatedQueryFrame.tsx
@@ -67,19 +67,15 @@ export function useDelayedFlag(active: boolean, delayMs: number): boolean {
 }
 
 /**
- * Safety net for clearing the blur-settling state when the content `filter` transition never
- * fires `transitionend` (e.g. jsdom, or a refetch so fast the transition never starts).
- * Generously above `--query-content-transition` (180ms) so on slow machines a genuine
- * `transitionend` still wins first.
+ * Clears the settling state when `transitionend` never fires (jsdom, or a refetch so fast the
+ * transition never starts). Well above `--query-content-transition` (180ms).
  */
 const BLUR_SETTLE_FALLBACK_MS = 600
 
 /**
- * True while the content blur is transitioning back to sharp after a refetch. `refreshing` flips
- * false the moment the query settles, but the blur-out transition keeps running after that —
- * clicks landing in that window hit content that is still blurred. Callers keep pointer events
- * blocked (and the refreshing testid attached) until `onContentTransitionEnd` sees the frame's
- * own `filter` transition finish, so neither users nor Playwright can click mid-transition.
+ * True while the blur is transitioning back to sharp after a refetch. `refreshing` flips false
+ * before the blur-out finishes, so clicks in that window would hit still-blurred content. Cleared
+ * when `onContentTransitionEnd` sees the frame's own `filter` transition finish.
  */
 function useBlurSettling(refreshing: boolean) {
   const [settling, setSettling] = useState(false)
@@ -101,8 +97,7 @@ function useBlurSettling(refreshing: boolean) {
   }, [refreshing])
 
   const onContentTransitionEnd = (event: React.TransitionEvent<HTMLDivElement>) => {
-    // Transitions bubbling up from children must not unblock early; only the frame's own blur
-    // transition counts.
+    // Ignore transitions bubbling from children and other properties.
     if (event.target === event.currentTarget && event.propertyName === "filter") {
       setSettling(false)
     }

--- a/shared-module/packages/components/src/components/queryResult/AnimatedQueryFrame.tsx
+++ b/shared-module/packages/components/src/components/queryResult/AnimatedQueryFrame.tsx
@@ -2,7 +2,7 @@
 
 import { cx } from "@emotion/css"
 import { motion, useReducedMotion } from "motion/react"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "../Button"
@@ -11,6 +11,7 @@ import type { RetryFn } from "./queryResultState"
 import { getErrorMessage } from "./queryResultState"
 import {
   animatedContentCss,
+  animatedContentNonInteractiveCss,
   animatedContentRefreshingCss,
   bannerCss,
   blockingErrorCss,
@@ -63,6 +64,51 @@ export function useDelayedFlag(active: boolean, delayMs: number): boolean {
   }, [active, delayMs])
 
   return visible
+}
+
+/**
+ * Safety net for clearing the blur-settling state when the content `filter` transition never
+ * fires `transitionend` (e.g. jsdom, or a refetch so fast the transition never starts).
+ * Generously above `--query-content-transition` (180ms) so on slow machines a genuine
+ * `transitionend` still wins first.
+ */
+const BLUR_SETTLE_FALLBACK_MS = 600
+
+/**
+ * True while the content blur is transitioning back to sharp after a refetch. `refreshing` flips
+ * false the moment the query settles, but the blur-out transition keeps running after that —
+ * clicks landing in that window hit content that is still blurred. Callers keep pointer events
+ * blocked (and the refreshing testid attached) until `onContentTransitionEnd` sees the frame's
+ * own `filter` transition finish, so neither users nor Playwright can click mid-transition.
+ */
+function useBlurSettling(refreshing: boolean) {
+  const [settling, setSettling] = useState(false)
+  const wasRefreshingRef = useRef(false)
+
+  useEffect(() => {
+    if (refreshing) {
+      wasRefreshingRef.current = true
+      setSettling(false)
+      return
+    }
+    if (!wasRefreshingRef.current) {
+      return
+    }
+    wasRefreshingRef.current = false
+    setSettling(true)
+    const fallback = setTimeout(() => setSettling(false), BLUR_SETTLE_FALLBACK_MS)
+    return () => clearTimeout(fallback)
+  }, [refreshing])
+
+  const onContentTransitionEnd = (event: React.TransitionEvent<HTMLDivElement>) => {
+    // Transitions bubbling up from children must not unblock early; only the frame's own blur
+    // transition counts.
+    if (event.target === event.currentTarget && event.propertyName === "filter") {
+      setSettling(false)
+    }
+  }
+
+  return { settling, onContentTransitionEnd }
 }
 
 export type AnimatedQueryFrameProps<E> = {
@@ -128,6 +174,7 @@ export function AnimatedQueryFrame<E>({
   const { t } = useTranslation()
   const shouldReduceMotion = !!useReducedMotion()
   const showDelayedSpinner = useDelayedFlag(initialLoading, loadingDelayMs)
+  const { settling: blurSettling, onContentTransitionEnd } = useBlurSettling(refreshing)
   const surfaceThemeCss =
     themeMode === "dark" ? initialLoadingSurfaceDarkCss : initialLoadingSurfaceLightCss
   const skeletonToneCss = themeMode === "dark" ? skeletonBlockDarkCss : skeletonBlockLightCss
@@ -192,9 +239,9 @@ export function AnimatedQueryFrame<E>({
   return (
     <section
       className={cx(wrapperCss, refreshing ? wrapperIsolationCss : undefined)}
-      aria-busy={refreshing ? "true" : undefined}
+      aria-busy={refreshing || blurSettling ? "true" : undefined}
       // eslint-disable-next-line i18next/no-literal-string
-      {...(refreshing && { "data-testid": "query-refreshing" })}
+      {...((refreshing || blurSettling) && { "data-testid": "query-refreshing" })}
     >
       {refreshing ? (
         <div
@@ -220,7 +267,12 @@ export function AnimatedQueryFrame<E>({
           </motion.div>
         ) : null}
         <div
-          className={cx(animatedContentCss, refreshing ? animatedContentRefreshingCss : undefined)}
+          className={cx(
+            animatedContentCss,
+            refreshing ? animatedContentRefreshingCss : undefined,
+            refreshing || blurSettling ? animatedContentNonInteractiveCss : undefined,
+          )}
+          onTransitionEnd={onContentTransitionEnd}
         >
           {children}
         </div>

--- a/shared-module/packages/components/src/components/queryResult/queryResultStyles.ts
+++ b/shared-module/packages/components/src/components/queryResult/queryResultStyles.ts
@@ -181,10 +181,8 @@ export const animatedContentRefreshingCss = css`
 `
 
 /**
- * Blocks clicks while the refresh blur is animating in, held, or animating out. Blurred content
- * looks non-interactive, and blocking pointer events makes that real: users cannot act on stale
- * content, and Playwright's "receives pointer events" actionability check makes `.click()` wait
- * until the content is sharp again instead of clicking mid-transition.
+ * Blocks clicks while the refresh blur is animating in, held, or animating out. Playwright's
+ * actionability checks make `.click()` wait for this to clear.
  */
 export const animatedContentNonInteractiveCss = css`
   pointer-events: none;

--- a/shared-module/packages/components/src/components/queryResult/queryResultStyles.ts
+++ b/shared-module/packages/components/src/components/queryResult/queryResultStyles.ts
@@ -180,6 +180,16 @@ export const animatedContentRefreshingCss = css`
   transform: scale(var(--query-refresh-content-scale));
 `
 
+/**
+ * Blocks clicks while the refresh blur is animating in, held, or animating out. Blurred content
+ * looks non-interactive, and blocking pointer events makes that real: users cannot act on stale
+ * content, and Playwright's "receives pointer events" actionability check makes `.click()` wait
+ * until the content is sharp again instead of clicking mid-transition.
+ */
+export const animatedContentNonInteractiveCss = css`
+  pointer-events: none;
+`
+
 export const errorTextCss = css`
   margin: 0 0 var(--space-3);
 `

--- a/storybook/stories/components/QueryResult.stories.tsx
+++ b/storybook/stories/components/QueryResult.stories.tsx
@@ -108,6 +108,7 @@ export const Refreshing: Story = {
       query={mockQuery({
         data: "Content while refetching",
         isPending: false,
+        isFetching: true,
         isRefetching: true,
       })}
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “refreshing” UI so the marker remains visible until the blur animation fully completes, with a timeout fallback if the expected transition doesn’t fire.
  * Disabled user interaction during the refresh blur settling phase to prevent premature clicking.
* **Tests**
  * Added test coverage ensuring the refreshing marker persists through relevant transition events and is removed via the fallback timer when needed.
* **Documentation**
  * Updated the Storybook “Refreshing” example to better simulate fetching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->