### PR TITLE
Reuse UserDisplay pill as the student cell across all students subtabs

### DIFF
--- a/services/main-frontend/src/app/manage/courses/[id]/students/studentsQueries.ts
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/studentsQueries.ts
@@ -22,6 +22,9 @@ export type StudentsSortColumn = "last_name" | "first_name" | "email"
 /** Detail subtabs (Completions/Progress/Certificates) only render the Student column as sortable. */
 export const DETAIL_SORT_COLUMNS: StudentsSortColumn[] = ["last_name"]
 
+/** Users tab: Student column sorts by last_name, Email column by email. */
+export const USERS_SORT_COLUMNS: StudentsSortColumn[] = ["last_name", "email"]
+
 export interface StudentsListParams {
   page: number
   limit: number

--- a/services/main-frontend/src/app/manage/courses/[id]/students/tabs/CertificatesTab.tsx
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/tabs/CertificatesTab.tsx
@@ -32,6 +32,7 @@ import {
 } from "../studentsQueries"
 import { StudentsTable } from "../StudentsTable"
 import { StaleTableWrapper } from "./StaleTableWrapper"
+import { StudentPillCell } from "./StudentPillCell"
 
 const CERTIFICATE_BY_VERIFICATION_PATH: GetCertificateByVerificationIdData["url"] =
   "/api/v0/main-frontend/certificates/{certificate_verification_id}"
@@ -50,6 +51,9 @@ const formatDateIssuedUtc = (value: string | null): string => {
 interface CertificateRow {
   user_id: string
   student: string
+  first_name: string | null | undefined
+  last_name: string | null | undefined
+  email: string | null | undefined
   name_on_certificate: string | null
   date_issued: string | null
   verification_id: string | null
@@ -151,6 +155,9 @@ export const CertificatesTabContent: React.FC = () => {
       return {
         user_id: u.user_id,
         student: formatStudentName(u, t),
+        first_name: u.first_name,
+        last_name: u.last_name,
+        email: u.email,
         name_on_certificate: cert?.name_on_certificate ?? null,
         date_issued: cert?.date_issued ?? null,
         verification_id: cert?.verification_id ?? null,
@@ -165,8 +172,19 @@ export const CertificatesTabContent: React.FC = () => {
 
   const columns = useMemo<ColumnDef<CertificateRow, unknown>[]>(
     () => [
-      // oxlint-disable-next-line i18next/no-literal-string
-      { id: "last_name", accessorKey: "student", header: t("label-student") },
+      {
+        // oxlint-disable-next-line i18next/no-literal-string
+        id: "last_name",
+        header: t("label-student"),
+        cell: ({ row }) => (
+          <StudentPillCell
+            userId={row.original.user_id}
+            firstName={row.original.first_name}
+            lastName={row.original.last_name}
+            email={row.original.email}
+          />
+        ),
+      },
       {
         // oxlint-disable-next-line i18next/no-literal-string
         id: "certificate",

--- a/services/main-frontend/src/app/manage/courses/[id]/students/tabs/CompletionsTab.tsx
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/tabs/CompletionsTab.tsx
@@ -21,10 +21,17 @@ import {
 import { StudentsTable } from "../StudentsTable"
 import { COMPLETIONS_LEAF_MIN_WIDTH } from "../studentsTableStyles"
 import { StaleTableWrapper } from "./StaleTableWrapper"
+import { StudentPillCell } from "./StudentPillCell"
 
 const PLACEHOLDER = "-"
 
-type CompletionRow = Record<string, unknown> & { user_id: string; student: string }
+type CompletionRow = Record<string, unknown> & {
+  user_id: string
+  student: string
+  first_name?: string | null | undefined
+  last_name?: string | null | undefined
+  email?: string | null | undefined
+}
 
 /** One completion column group: keyed by the module's id (names are not unique), labelled by name. */
 interface ModuleColumn {
@@ -42,7 +49,12 @@ const needsReviewKeyOf = (moduleId: string) => `${moduleId}__needsReview`
  * `module_id` (names are not unique) so modules with identical names never collide onto the same cells.
  */
 const pivotCompletions = (
-  identityRows: { user_id: string; first_name?: string | null; last_name?: string | null }[],
+  identityRows: {
+    user_id: string
+    first_name?: string | null
+    last_name?: string | null
+    email?: string | null
+  }[],
   completions: CompletionGridRow[],
   t: TFunction,
 ) => {
@@ -67,6 +79,9 @@ const pivotCompletions = (
   const data: CompletionRow[] = identityRows.map((u) => ({
     user_id: u.user_id,
     student: formatStudentName(u, t),
+    first_name: u.first_name,
+    last_name: u.last_name,
+    email: u.email,
     ...byUser.get(u.user_id),
   }))
   return { modulesInOrder, data }
@@ -84,13 +99,6 @@ const gradeLabel = (grade: unknown, passed: unknown, t: TFunction): string => {
   }
   return PLACEHOLDER
 }
-
-const studentEllipsis = css`
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`
 
 const statusCellClass = css`
   display: flex;
@@ -123,10 +131,15 @@ const buildColumns = (
       // oxlint-disable-next-line i18next/no-literal-string
       id: "last_name",
       header: t("label-student"),
-      // oxlint-disable-next-line i18next/no-literal-string
-      accessorKey: "student",
       meta: { minWidth: 80 },
-      cell: ({ getValue }) => <span className={studentEllipsis}>{String(getValue() ?? "")}</span>,
+      cell: ({ row }) => (
+        <StudentPillCell
+          userId={row.original.user_id}
+          firstName={row.original.first_name}
+          lastName={row.original.last_name}
+          email={row.original.email}
+        />
+      ),
     },
   ]
 

--- a/services/main-frontend/src/app/manage/courses/[id]/students/tabs/ProgressTab.tsx
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/tabs/ProgressTab.tsx
@@ -22,12 +22,16 @@ import {
 } from "../studentsQueries"
 import { StudentsTable } from "../StudentsTable"
 import { StaleTableWrapper } from "./StaleTableWrapper"
+import { StudentPillCell } from "./StudentPillCell"
 
 type ChapterCellKey = `ch_${string}_${"points" | "attempts"}`
 
 type ProgressRow = {
   user_id: string
   student: string
+  first_name?: string | null | undefined
+  last_name?: string | null | undefined
+  email?: string | null | undefined
   total_points: number
   total_attempted: number
 } & Partial<Record<ChapterCellKey, number | string | React.ReactNode | undefined>>
@@ -97,8 +101,14 @@ export const ProgressTabContent: React.FC = () => {
         // oxlint-disable-next-line i18next/no-literal-string
         id: "last_name",
         header: t("label-student"),
-        // oxlint-disable-next-line i18next/no-literal-string
-        accessorKey: "student",
+        cell: ({ row }) => (
+          <StudentPillCell
+            userId={row.original.user_id}
+            firstName={row.original.first_name}
+            lastName={row.original.last_name}
+            email={row.original.email}
+          />
+        ),
       },
       {
         header: t("total"),
@@ -176,6 +186,9 @@ export const ProgressTabContent: React.FC = () => {
       const row: ProgressRow = {
         user_id: u.user_id,
         student: formatStudentName(u, t),
+        first_name: u.first_name,
+        last_name: u.last_name,
+        email: u.email,
         total_points: totals.total_points,
         total_attempted: totals.total_attempted,
       }

--- a/services/main-frontend/src/app/manage/courses/[id]/students/tabs/StudentPillCell.tsx
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/tabs/StudentPillCell.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import React from "react"
+
+import { UserDisplay } from "@/components/UserDisplay"
+
+import { useStudentsContext } from "../StudentsContext"
+
+export interface StudentPillCellProps {
+  userId: string
+  firstName?: string | null | undefined
+  lastName?: string | null | undefined
+  email?: string | null | undefined
+}
+
+/**
+ * Students-tab student cell: the UserDisplay pill fed from row data (`courseId` comes from context),
+ * so the popover's details load only on open instead of one fetch per row.
+ */
+export const StudentPillCell: React.FC<StudentPillCellProps> = ({
+  userId,
+  firstName,
+  lastName,
+  email,
+}) => {
+  const { courseId } = useStudentsContext()
+  return (
+    <UserDisplay
+      userId={userId}
+      courseId={courseId}
+      prefetchedIdentity={{ firstName, lastName, email }}
+    />
+  )
+}

--- a/services/main-frontend/src/app/manage/courses/[id]/students/tabs/UserTab.tsx
+++ b/services/main-frontend/src/app/manage/courses/[id]/students/tabs/UserTab.tsx
@@ -8,9 +8,10 @@ import type { CourseStudentListRow } from "@/generated/api/types.generated"
 import { QueryResult } from "@/shared-module/components"
 
 import { useStudentsContext, useStudentsListParams, useStudentsSorting } from "../StudentsContext"
-import { useCourseStudentsIdentity } from "../studentsQueries"
+import { USERS_SORT_COLUMNS, useCourseStudentsIdentity } from "../studentsQueries"
 import { StudentsTable } from "../StudentsTable"
 import { StaleTableWrapper } from "./StaleTableWrapper"
+import { StudentPillCell } from "./StudentPillCell"
 
 const EM_DASH = "—"
 
@@ -18,7 +19,7 @@ export const UserTabContent: React.FC = () => {
   const { t } = useTranslation()
   const { courseId } = useStudentsContext()
   const params = useStudentsListParams()
-  const { sorting, onSortingChange } = useStudentsSorting()
+  const { sorting, onSortingChange } = useStudentsSorting(USERS_SORT_COLUMNS)
 
   const query = useCourseStudentsIdentity(courseId, params)
   const deferredData = useDeferredValue(query.data)
@@ -28,22 +29,18 @@ export const UserTabContent: React.FC = () => {
   const columns = useMemo<ColumnDef<CourseStudentListRow, unknown>[]>(
     () => [
       {
-        header: t("user-id"),
+        // id drives the shared `last_name` sort key; the pill shows the name and opens the details popover.
         // oxlint-disable-next-line i18next/no-literal-string
-        accessorKey: "user_id",
-        enableSorting: false,
-      },
-      {
-        header: t("first-name"),
-        // oxlint-disable-next-line i18next/no-literal-string
-        accessorKey: "first_name",
-        cell: ({ getValue }) => getValue<string | null>() ?? EM_DASH,
-      },
-      {
-        header: t("last-name"),
-        // oxlint-disable-next-line i18next/no-literal-string
-        accessorKey: "last_name",
-        cell: ({ getValue }) => getValue<string | null>() ?? EM_DASH,
+        id: "last_name",
+        header: t("label-student"),
+        cell: ({ row }) => (
+          <StudentPillCell
+            userId={row.original.user_id}
+            firstName={row.original.first_name}
+            lastName={row.original.last_name}
+            email={row.original.email}
+          />
+        ),
       },
       {
         header: t("label-email"),

--- a/services/main-frontend/src/components/UserDisplay/index.tsx
+++ b/services/main-frontend/src/components/UserDisplay/index.tsx
@@ -21,10 +21,47 @@ function hasName(value: string | null | undefined): boolean {
   return !!value && value.trim().length > 0
 }
 
+interface Identity {
+  firstName?: string | null | undefined
+  lastName?: string | null | undefined
+  email?: string | null | undefined
+}
+
+/** Badge text ("First Last", else email, else userId) and avatar initial from an identity. */
+function computeLabel(
+  identity: Identity,
+  userId: string,
+): { displayText: string; initial: string } {
+  const firstName = identity.firstName?.trim() ?? ""
+  const lastName = identity.lastName?.trim() ?? ""
+  const email = identity.email?.trim() ?? ""
+
+  const displayText =
+    hasName(firstName) || hasName(lastName)
+      ? [firstName, lastName].filter(Boolean).join(" ")
+      : email || userId
+
+  const initial = hasName(firstName)
+    ? (firstName[0]?.toUpperCase() ?? "?")
+    : hasName(lastName)
+      ? (lastName[0]?.toUpperCase() ?? "?")
+      : email
+        ? (email[0]?.toUpperCase() ?? "?")
+        : "?"
+
+  return { displayText, initial }
+}
+
 /** Props: userId (required), courseId (optional). */
 export interface UserDisplayProps {
   userId: string
   courseId: string | null | undefined
+  /**
+   * When supplied (e.g. from a table row that already has the identity), the badge renders from it
+   * immediately and the user-details fetch is deferred until the popover opens — avoiding one request
+   * per row. Omit it to fetch details on mount (the default the manual-review call sites rely on).
+   */
+  prefetchedIdentity?: Identity
 }
 
 const popEnterKeyframes = keyframes`
@@ -78,7 +115,7 @@ const badgeStyle = css`
 `
 
 /** Renders user avatar (first letter) and display name or email. */
-const UserDisplay: React.FC<UserDisplayProps> = ({ userId, courseId }) => {
+const UserDisplay: React.FC<UserDisplayProps> = ({ userId, courseId, prefetchedIdentity }) => {
   const { t } = useTranslation()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const state = useOverlayTriggerState({})
@@ -88,6 +125,8 @@ const UserDisplay: React.FC<UserDisplayProps> = ({ userId, courseId }) => {
     staleTime: 30 * 60 * 1000,
     gcTime: 24 * 60 * 60 * 1000,
     refetchOnWindowFocus: false,
+    // With a prefetched identity the badge needs no fetch, so defer details until the popover opens.
+    ...(prefetchedIdentity ? { enabled: state.isOpen } : {}),
   })
 
   const { buttonProps } = useButton(
@@ -115,101 +154,91 @@ const UserDisplay: React.FC<UserDisplayProps> = ({ userId, courseId }) => {
     return userIdFallback
   }
 
+  const renderBadgeAndPopover = (displayText: string, initial: string) => (
+    <>
+      <button
+        ref={triggerRef}
+        {...buttonProps}
+        type="button"
+        aria-label={t("view-details")}
+        className={badgeStyle}
+      >
+        <span
+          className={css`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 1.5rem;
+            height: 1.5rem;
+            border-radius: 50%;
+            background: ${baseTheme.colors.green[200]};
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: ${baseTheme.colors.gray[700]};
+          `}
+          aria-hidden
+        >
+          {initial}
+        </span>
+        {displayText}
+      </button>
+      {state.isOpen && (
+        <UserDetailsPopover
+          state={state}
+          triggerRef={triggerRef}
+          overlayProps={overlayProps}
+          className={popoverStyle}
+          aria-label={t("header-user-details")}
+        >
+          <QueryResult query={userDetailsQuery}>
+            {(data) => {
+              const user = extractUserDetail(data)
+              return user ? <UserDetailsContent data={user} userId={userId} /> : userIdFallback
+            }}
+          </QueryResult>
+          <CourseProgressSection courseId={courseId} userId={userId} />
+          <div
+            className={css`
+              margin-top: 0.75rem;
+              display: flex;
+              justify-content: center;
+            `}
+          >
+            <Link
+              href={courseUserStatusSummaryRoute(courseId, userId)}
+              className={css`
+                text-decoration: none;
+              `}
+            >
+              <Button variant="tertiary" size="small">
+                {t("course-status-summary")}
+              </Button>
+            </Link>
+          </div>
+        </UserDetailsPopover>
+      )}
+    </>
+  )
+
+  // Prefetched: render the badge from row data immediately; details load when the popover opens.
+  if (prefetchedIdentity) {
+    const { displayText, initial } = computeLabel(prefetchedIdentity, userId)
+    return renderBadgeAndPopover(displayText, initial)
+  }
+
+  // No prefetched identity: the badge label comes from the fetched user, so gate on the query.
   return (
     <QueryResult query={userDetailsQuery}>
       {(data) => {
         const user = extractUserDetail(data)
-
         if (!user) {
           return userIdFallback
         }
-
-        const firstName = user.first_name?.trim() ?? ""
-        const lastName = user.last_name?.trim() ?? ""
-        const email = user.email?.trim() ?? ""
-
-        const displayText =
-          hasName(firstName) || hasName(lastName)
-            ? [firstName, lastName].filter(Boolean).join(" ")
-            : email || userId
-
-        const initial = hasName(firstName)
-          ? // safe: hasName ensures non-empty string
-            (firstName[0]?.toUpperCase() ?? "?")
-          : hasName(lastName)
-            ? (lastName[0]?.toUpperCase() ?? "?")
-            : email
-              ? (email[0]?.toUpperCase() ?? "?")
-              : "?"
-
-        const badgeContent = (
-          <>
-            <span
-              className={css`
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                width: 1.5rem;
-                height: 1.5rem;
-                border-radius: 50%;
-                background: ${baseTheme.colors.green[200]};
-                font-size: 0.8rem;
-                font-weight: 600;
-                color: ${baseTheme.colors.gray[700]};
-              `}
-              aria-hidden
-            >
-              {initial}
-            </span>
-            {displayText}
-          </>
+        const { displayText, initial } = computeLabel(
+          { firstName: user.first_name, lastName: user.last_name, email: user.email },
+          userId,
         )
-
-        return (
-          <>
-            <button
-              ref={triggerRef}
-              {...buttonProps}
-              type="button"
-              aria-label={t("view-details")}
-              className={badgeStyle}
-            >
-              {badgeContent}
-            </button>
-            {state.isOpen && (
-              <UserDetailsPopover
-                state={state}
-                triggerRef={triggerRef}
-                overlayProps={overlayProps}
-                className={popoverStyle}
-                aria-label={t("header-user-details")}
-              >
-                <UserDetailsContent data={user} userId={userId} />
-                {courseId && <CourseProgressSection courseId={courseId} userId={userId} />}
-                {courseId && (
-                  <div
-                    className={css`
-                      margin-top: 0.75rem;
-                      display: flex;
-                      justify-content: center;
-                    `}
-                  >
-                    <Link
-                      href={courseUserStatusSummaryRoute(courseId, userId)}
-                      className={css`
-                        text-decoration: none;
-                      `}
-                    >
-                      <Button variant="tertiary" size="small">
-                        {t("course-status-summary")}
-                      </Button>
-                    </Link>
-                  </div>
-                )}
-              </UserDetailsPopover>
-            )}
-          </>
-        )
+        return renderBadgeAndPopover(displayText, initial)
       }}
     </QueryResult>
   )

--- a/services/main-frontend/src/hooks/useUserDetails.ts
+++ b/services/main-frontend/src/hooks/useUserDetails.ts
@@ -10,6 +10,7 @@ export interface UseUserDetailsOptions {
   staleTime?: number
   gcTime?: number
   refetchOnWindowFocus?: boolean
+  enabled?: boolean
 }
 
 export type UserDetailsResult =
@@ -112,6 +113,8 @@ export const useUserDetails = (
   return useQuery({
     ...optionalGeneratedQueryOptions({
       value: courseIds && userId ? { courseIds, userId } : null,
+      // Combined with the readiness gate below: the query only runs when both are true.
+      enabled: options?.enabled ?? true,
       isReady: (
         value,
       ): value is {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Student lists and course tables now display students as interactive identity pills with names, email addresses, and user IDs.
  * Student details can appear immediately using available row information, with additional details loaded when needed.
  * Added sorting support for students by last name and email.
* **Improvements**
  * Updated Certificates, Completions, Progress, and Users tabs to use the enhanced student display.
  * Improved control over when student details are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->