### PR TITLE
Show readable error when a course slug is already taken

### DIFF
--- a/services/headless-lms/models/.sqlx/query-76ac3c2f7a057a80734bf56bb4e34d01edb42ee4c471bf0ebf9cb2fd6b0e83bc.json
+++ b/services/headless-lms/models/.sqlx/query-76ac3c2f7a057a80734bf56bb4e34d01edb42ee4c471bf0ebf9cb2fd6b0e83bc.json
@@ -76,12 +76,12 @@
       ]
     },
     "nullable": [
-      true,
-      true,
-      true,
-      true,
       false,
-      false
+      false,
+      true,
+      true,
+      true,
+      true
     ]
   },
   "hash": "76ac3c2f7a057a80734bf56bb4e34d01edb42ee4c471bf0ebf9cb2fd6b0e83bc"

--- a/services/headless-lms/models/src/error.rs
+++ b/services/headless-lms/models/src/error.rs
@@ -265,13 +265,13 @@ impl From<sqlx::Error> for ModelError {
                             Some(err.into()),
                         ),
                         "courses_slug_key_when_not_deleted"
-                        | "course_language_groups_slug_unique_non_deleted" => ModelError::new(
-                            ModelErrorType::DatabaseConstraint {
+                        | "course_language_groups_slug_unique_non_deleted" => model_err!(
+                            DatabaseConstraint {
                                 constraint: constraint.to_string(),
                                 description: "A course with this slug already exists.",
                             },
                             err.to_string(),
-                            Some(err.into()),
+                            err
                         ),
                         "unique_chatbot_names_within_course" => ModelError::new(
                             ModelErrorType::DatabaseConstraint {

--- a/services/headless-lms/models/src/error.rs
+++ b/services/headless-lms/models/src/error.rs
@@ -264,6 +264,15 @@ impl From<sqlx::Error> for ModelError {
                             err.to_string(),
                             Some(err.into()),
                         ),
+                        "courses_slug_key_when_not_deleted"
+                        | "course_language_groups_slug_unique_non_deleted" => ModelError::new(
+                            ModelErrorType::DatabaseConstraint {
+                                constraint: constraint.to_string(),
+                                description: "A course with this slug already exists.",
+                            },
+                            err.to_string(),
+                            Some(err.into()),
+                        ),
                         "unique_chatbot_names_within_course" => ModelError::new(
                             ModelErrorType::DatabaseConstraint {
                                 constraint: constraint.to_string(),
@@ -561,6 +570,27 @@ mod test {
         match err.error_type {
             ModelErrorType::DatabaseConstraint { constraint, .. } => {
                 assert_eq!(constraint, "email_templates_subject_check");
+            }
+            _ => {
+                panic!("wrong error variant")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn course_language_groups_slug_uniqueness() {
+        let mut conn = Conn::init().await;
+        let mut tx = conn.begin().await;
+        crate::course_language_groups::insert(tx.as_mut(), PKeyPolicy::Generate, "taken-slug")
+            .await
+            .unwrap();
+        let err =
+            crate::course_language_groups::insert(tx.as_mut(), PKeyPolicy::Generate, "taken-slug")
+                .await
+                .unwrap_err();
+        match err.error_type {
+            ModelErrorType::DatabaseConstraint { constraint, .. } => {
+                assert_eq!(constraint, "course_language_groups_slug_unique_non_deleted");
             }
             _ => {
                 panic!("wrong error variant")

--- a/services/headless-lms/server/src/domain/error.rs
+++ b/services/headless-lms/server/src/domain/error.rs
@@ -46,6 +46,10 @@ pub enum ControllerErrorType {
     #[display("Bad request")]
     BadRequestWithData(ErrorMetadata),
 
+    /// HTTP status code 422 with a specific domain reason.
+    #[display("Bad request")]
+    BadRequestWithReason(BadRequestReason),
+
     /// HTTP status code 404.
     #[display("Not found")]
     NotFound,
@@ -88,6 +92,34 @@ impl UnauthorizedReason {
             Self::AuthenticationRequiredForExamExercise => {
                 "authentication_required_for_exam_exercise"
             }
+        }
+    }
+}
+
+/// Bad request reasons that the frontend has a translated message for.
+#[derive(Debug, Display, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BadRequestReason {
+    #[display("Course slug already taken")]
+    CourseSlugAlreadyTaken,
+}
+
+impl BadRequestReason {
+    /// Returns the stable message key for this bad request reason.
+    fn message_key(self) -> &'static str {
+        match self {
+            Self::CourseSlugAlreadyTaken => "course_slug_already_taken",
+        }
+    }
+
+    /// Both slug indexes collapse into one reason: they guard the same user mistake.
+    fn from_database_constraint(constraint: &str) -> Option<Self> {
+        match constraint {
+            "courses_slug_key_when_not_deleted"
+            | "course_language_groups_slug_unique_non_deleted" => {
+                Some(Self::CourseSlugAlreadyTaken)
+            }
+            _ => None,
         }
     }
 }
@@ -473,6 +505,7 @@ impl error::ResponseError for ControllerError {
             ControllerErrorType::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             ControllerErrorType::BadRequest => StatusCode::UNPROCESSABLE_ENTITY,
             ControllerErrorType::BadRequestWithData(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            ControllerErrorType::BadRequestWithReason(_) => StatusCode::UNPROCESSABLE_ENTITY,
             ControllerErrorType::NotFound => StatusCode::NOT_FOUND,
             ControllerErrorType::Unauthorized => StatusCode::UNAUTHORIZED,
             ControllerErrorType::UnauthorizedWithReason(_) => StatusCode::UNAUTHORIZED,
@@ -498,6 +531,9 @@ impl ControllerError {
             ControllerErrorType::BadRequest => ("validation_error", "validation_error"),
             ControllerErrorType::BadRequestWithData(_) => {
                 ("validation_error", "validation_error_with_metadata")
+            }
+            ControllerErrorType::BadRequestWithReason(reason) => {
+                ("validation_error", reason.message_key())
             }
             ControllerErrorType::NotFound => ("not_found", "not_found"),
             ControllerErrorType::Unauthorized => ("unauthorized", "unauthorized"),
@@ -680,8 +716,14 @@ impl From<ModelError> for ControllerError {
                     span_trace,
                 )
             }
-            ModelErrorType::DatabaseConstraint { description, .. } => Self::new_with_traces(
-                ControllerErrorType::BadRequest,
+            ModelErrorType::DatabaseConstraint {
+                constraint,
+                description,
+            } => Self::new_with_traces(
+                BadRequestReason::from_database_constraint(constraint)
+                    .map_or(ControllerErrorType::BadRequest, |reason| {
+                        ControllerErrorType::BadRequestWithReason(reason)
+                    }),
                 description.to_string(),
                 Some(err.into()),
                 backtrace,

--- a/services/main-frontend/src/hooks/useCreateCourse.tsx
+++ b/services/main-frontend/src/hooks/useCreateCourse.tsx
@@ -103,7 +103,8 @@ export const useCreateCourse = () => {
       notify: true,
       method: "POST",
       successMessage: t("course-created-successfully"),
-      errorMessage: t("error-creating-course"),
+      // No errorMessage: it would override the localized backend copy, e.g. a taken slug.
+      errorHeader: t("error-creating-course"),
     },
     {
       // oxlint-disable-next-line eslint/require-await -- async; react-query awaits the onSuccess promise

--- a/shared-module/packages/common/src/errors/__tests__/resolveErrorDisplayCopy.test.ts
+++ b/shared-module/packages/common/src/errors/__tests__/resolveErrorDisplayCopy.test.ts
@@ -12,6 +12,9 @@ const translations: Record<string, string> = {
   "error-message-key.authentication_required_for_exam_exercise.title": "Sign in required",
   "error-message-key.authentication_required_for_exam_exercise.message":
     "Please sign in to view exam exercises.",
+  "error-message-key.course_slug_already_taken.title": "Slug is already in use",
+  "error-message-key.course_slug_already_taken.message":
+    "Another course is already using this slug. Please choose a different one.",
   "error-issue-code.missing_exercise_type.message": "Missing exercise type for exercise task.",
 }
 
@@ -69,6 +72,27 @@ describe("resolveErrorDisplayCopy", () => {
 
     expect(resolved.title).toBe("Chapter is closed")
     expect(resolved.message).toBe("This chapter is not open yet.")
+  })
+
+  test("uses localized copy for course_slug_already_taken message key", () => {
+    const view = normalizeErrorForDisplay(
+      {
+        type: "validation_error",
+        message_key: "course_slug_already_taken",
+        message: "A course with this slug already exists.",
+        errors: [],
+      },
+      t,
+    )
+
+    expect(view.category).toBe("validation")
+
+    const resolved = resolveErrorDisplayCopy(view, t)
+
+    expect(resolved.title).toBe("Slug is already in use")
+    expect(resolved.message).toBe(
+      "Another course is already using this slug. Please choose a different one.",
+    )
   })
 
   test("uses localized copy for authentication_required_for_exam_exercise message key", () => {

--- a/shared-module/packages/common/src/errors/normalizeErrorForDisplay.ts
+++ b/shared-module/packages/common/src/errors/normalizeErrorForDisplay.ts
@@ -23,6 +23,7 @@ export type BackendMessageKey =
   | "validation_error"
   | "response_validation_error"
   | "validation_error_with_metadata"
+  | "course_slug_already_taken"
   | "not_found"
   | "unauthorized"
   | "chapter_not_open_yet"
@@ -76,6 +77,7 @@ function isBackendMessageKey(value: unknown): value is BackendMessageKey {
     value === "validation_error" ||
     value === "response_validation_error" ||
     value === "validation_error_with_metadata" ||
+    value === "course_slug_already_taken" ||
     value === "not_found" ||
     value === "unauthorized" ||
     value === "chapter_not_open_yet" ||
@@ -244,6 +246,7 @@ function normalizePayload(payload: SimplifiedPayload, t: TFunction): ErrorViewMo
       ? "rate_limit"
       : messageKey === "validation_error" ||
           messageKey === "validation_error_with_metadata" ||
+          messageKey === "course_slug_already_taken" ||
           messageKey === "response_validation_error"
         ? "validation"
         : messageKey === "unauthorized" ||

--- a/shared-module/packages/common/src/locales/en/shared-module.json
+++ b/shared-module/packages/common/src/locales/en/shared-module.json
@@ -79,6 +79,10 @@
       "message": "This chapter is not open yet.",
       "title": "Chapter is closed"
     },
+    "course_slug_already_taken": {
+      "message": "Another course is already using this slug. Please choose a different one.",
+      "title": "Slug is already in use"
+    },
     "forbidden": {
       "message": "You do not have permission for this action.",
       "title": "Forbidden"

--- a/shared-module/packages/common/src/locales/fi/shared-module.json
+++ b/shared-module/packages/common/src/locales/fi/shared-module.json
@@ -73,6 +73,10 @@
     "chapter_not_open_yet": {
       "message": "Tämä luku ei ole vielä avoinna.",
       "title": "Luku on suljettu"
+    },
+    "course_slug_already_taken": {
+      "message": "Toinen kurssi käyttää jo tätä lyhyttä nimeä. Valitse jokin muu.",
+      "title": "Lyhyt nimi on jo käytössä"
     }
   },
   "error-part-of-page-has-crashed-error": "Osa sivusta on kaatunut: {{error}}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Course creation now clearly reports when the chosen course slug is already in use.
  * Duplicate slug errors are identified as validation errors with an appropriate HTTP response.
  * Error details are displayed more clearly during course creation.

* **Localization**
  * Added localized duplicate-slug titles and messages in English and Finnish.

* **Tests**
  * Added coverage confirming duplicate course slugs are correctly detected and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->