### PR TITLE
Stop the out-of-tries notice from following students into peer review

### DIFF
--- a/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/OutOfTriesNotification.tsx
+++ b/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/OutOfTriesNotification.tsx
@@ -4,20 +4,26 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 
 import YellowBox from "@/components/course-material/YellowBox"
+import type { ReviewingStage } from "@/generated/course-material-api/types.generated"
 
 export interface OutOfTriesNotificationProps {
   ranOutOfTries: boolean
+  /** Undefined for exams, which have no reviewing stage. */
+  reviewingStage: ReviewingStage | undefined
 }
 
 // Wrapper stays mounted with role="status" so screen readers announce the message when it appears.
-const OutOfTriesNotification: React.FC<OutOfTriesNotificationProps> = ({ ranOutOfTries }) => {
+const OutOfTriesNotification: React.FC<OutOfTriesNotificationProps> = ({
+  ranOutOfTries,
+  reviewingStage,
+}) => {
   const { t } = useTranslation()
 
-  return (
-    <div role="status">
-      {ranOutOfTries && <YellowBox>{t("out-of-tries-description")}</YellowBox>}
-    </div>
-  )
+  // The try limit only ever stops a new answer, but the message reads as a blanket ban: next to
+  // the peer review form it looks like peer reviewing is out of tries too.
+  const show = ranOutOfTries && (reviewingStage === undefined || reviewingStage === "NotStarted")
+
+  return <div role="status">{show && <YellowBox>{t("out-of-tries-description")}</YellowBox>}</div>
 }
 
 export default OutOfTriesNotification

--- a/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/__tests__/OutOfTriesNotification.test.tsx
+++ b/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/__tests__/OutOfTriesNotification.test.tsx
@@ -8,12 +8,12 @@ import OutOfTriesNotification from "../OutOfTriesNotification"
 // react-i18next is mocked in tests/setup-jest.js, so t() returns the translation key.
 describe("OutOfTriesNotification", () => {
   it("renders a persistent status live region even when tries remain", () => {
-    render(<OutOfTriesNotification ranOutOfTries={false} />)
+    render(<OutOfTriesNotification ranOutOfTries={false} reviewingStage="NotStarted" />)
     expect(screen.getByRole("status")).toBeEmptyDOMElement()
   })
 
   it("announces and shows the message when the user has run out of tries (WCAG 4.1.3)", () => {
-    render(<OutOfTriesNotification ranOutOfTries={true} />)
+    render(<OutOfTriesNotification ranOutOfTries={true} reviewingStage="NotStarted" />)
     expect(screen.getByRole("status")).toHaveTextContent("out-of-tries-description")
   })
 })

--- a/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/index.tsx
+++ b/services/main-frontend/src/components/course-material/ContentRenderer/moocfi/ExerciseBlock/index.tsx
@@ -852,7 +852,10 @@ const ExerciseBlock: React.FC<
                     </div>
                   </YellowBox>
                 )}
-              <OutOfTriesNotification ranOutOfTries={Boolean(ranOutOfTries)} />
+              <OutOfTriesNotification
+                ranOutOfTries={Boolean(ranOutOfTries)}
+                reviewingStage={reviewingStage}
+              />
               <div>
                 {!inSubmissionView && !isChapterLocked && (
                   <ExerciseSubmitButton


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “out of tries” notification is now hidden while a peer review form is active.
  * The notification continues to appear when no review has started and all exercise attempts have been used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->